### PR TITLE
ACRS-33 Choose how to sign-in BRP/UAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 
 ## Install prerequisites
 
+### Database setup and integration
+If this is a first-time install get postgres running on the default port and setup a new, empty local database called `acrs`.  
+Run [hof-rds-api](https://github.com/UKHomeOffice/hof-rds-api) locally for the acrs service. Hof-rds-api is an api that will read and write to your local database.  
+Follow the instructions in the [hof-rds-api README](https://github.com/UKHomeOffice/hof-rds-api/blob/master/README.md) to setup the correct configuration for your local `acrs` database and run the api in relation to acrs.
+
+### Project setup and Run ACRS
 Step 1 : Install Node Version Manager
 
         curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
@@ -29,26 +35,6 @@ Step 7: yarn run start:dev
 - NPM (installed with Node.js) - Works with versions 2 and 3
 - [Redis server](http://redis.io/download) running on the default port
 
-
-### Database setup and integration
-
-If this is a first-time install get postgres running on the default port and setup a new, empty local database called `acrs`.  
-Run [hof-rds-api](https://github.com/UKHomeOffice/hof-rds-api) locally for the ima service. Hof-rds-api is an api that will read and write to your local database.  
-Follow the instructions in the [hof-rds-api README](https://github.com/UKHomeOffice/hof-rds-api/blob/master/README.md) to setup the correct configuration for your local `acrs` database and run the api in relation to acrs.
-
-### Run IMA
-
-First make sure you have the hof-rds-api running for the 'acrs' service and a local database setup for it to read and write to. If not follow the steps in the [Database setup and integration](#database-setup-and-integration) section above.
-
-Clone this repository to your local machine then:
-
-```bash
-$ cd acrs
-$ touch .env
-$ yarn install
-$ yarn start:dev
-```
-
 Then visit: [http://localhost:8080/](http://localhost:8080/) For the start page and applicant journey
 
 
@@ -58,11 +44,11 @@ You can skip the email authentication locally or in some of the testing environm
 
 1. To use an email environment variable, you'll need to set it like so `skipEmail=sas-hof-test@digital.homeoffice.gov.uk`. You can then go to the following url.
 
-    http://localhost:8080/ima/start?token=skip
+    http://localhost:8080/acrs/start?token=skip
 
 2. Set the email in the url to whatever email you like.
 
-    http://localhost:8080/ima/start?token=skip&email=sas-hof-test@digital.homeoffice.gov.uk
+    http://localhost:8080/acrs/start?token=skip&email=sas-hof-test@digital.homeoffice.gov.uk
 
 3. If you do both, then the app will always use what you've set in the url parameter as the email.
 

--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -1,3 +1,12 @@
 'use strict';
 
-module.exports = {};
+module.exports = {
+  'sign-in-choice': {
+    mixin: 'radio-group',
+    options: ['brp', 'uan'],
+    validate: 'required',
+    legend: {
+      className: 'visuallyhidden'
+    }
+  }
+};

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -6,8 +6,64 @@ module.exports = {
   name: 'acrs',
   params: '/:action?/:id?/:edit?',
   baseUrl: '/acrs',
+  pages: {
+    '/terms-and-conditions': 'terms',
+    '/cookies': 'cookies'
+  },
   steps: {
-    '/start': {
+    '/sign-in': {
+      fields: ['sign-in-choice'],
+      forks: [{
+        target: '/sign-in-brp',
+        condition: {
+          field: 'sign-in-choice',
+          value: 'brp'
+        }
+      }],
+      next: '/sign-in-uan'
+    },
+    'sign-in-brp': {
+      fields: [],
+      next: '/sign-in-email'
+    },
+    '/sign-in-uan': {
+      fields: [],
+      next: '/sign-in-email'
+    },
+    '/sign-in-email': {
+      fields: [],
+      next: '/check-email'
+    },
+    '/check-email': {
+      fields: [],
+      next: '/select-form'
+    },
+    '/select-form': {
+      fields: [],
+      next: '/who-is-completing-form'
+    },
+    '/information-you-have-given-us': {
+      fields: [],
+      next: '/who-is-completing-form'
+    },
+    '/who-is-completing-form': {
+      fields: [],
+      next: '/full-name'
+    },
+    '/full-name': {
+      fields: [],
+      next: '/confirm'
+    },
+    '/session-expired': {
+      fields: [],
+      next: '/confirm'
+    },
+    '/link-expired': {
+      fields: [],
+      next: '/confirm'
+    },
+    '/information-saved': {
+      fields: [],
       next: '/confirm'
     },
     '/confirm': {

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -1,2 +1,14 @@
 {
+    "sign-in-choice": {
+        "label": "You can use a biometric residence permit(BRP) number or a unique application number",
+        "options": {
+          "brp": {
+            "label": "Using a BRP number",
+            "hint": "For example, RZ123456"
+          },
+          "uan": {
+            "label": "Using a UAN"
+          }
+        }
+    }
 }

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -1,6 +1,6 @@
 {
-  "start": {
-    "header": "Afghan Citizens Resettlement Scheme"
+  "sign-in": {
+    "header": "How do you want to sign in?"
   },
   "confirm": {
     "header": "Check your answers",

--- a/apps/verify/translations/src/en/fields.json
+++ b/apps/verify/translations/src/en/fields.json
@@ -8,7 +8,7 @@
       },
       "uan": {
         "label": "Using a UAN",
-        "hint": "For example, 1111-2222-3333-4444"
+        "hint": "For example, 1234-1234-1234-1234"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generate:local:reports": "node -r dotenv/config ./services/reports/generate_reports.js",
     "test:unit": "nyc _mocha \"test/_unit/**/*.spec.js\"",
     "test:snyk": "snyk config set api=SNYK_TOKEN && snyk test",
-    "postinstall": "hof-build"
+    "postinstall": "yarn run build"
   },
   "dependencies": {
     "accessible-autocomplete": "^2.0.4",


### PR DESCRIPTION
## What? 
[ACRS-33 ](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-33) - Choose how to sign in (BRP/UAN)

## Why? 
Should follow figma design and allow applicant to select different options 

## How? 
- Edited the readme file
- Replace the field label for uan and brp in the fields.json file

## Testing?
tested locally on machine

## Screenshots (optional)
![Screenshot 2024-05-03 at 11 20 24](https://github.com/UKHomeOffice/acrs/assets/138882912/3b5934d5-d4eb-4ec2-b344-6c7a129bc87f)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
