### PR TITLE
ACRS-14-Brp and dob details

### DIFF
--- a/apps/verify/translations/src/en/fields.json
+++ b/apps/verify/translations/src/en/fields.json
@@ -14,7 +14,7 @@
   },
   "brp": {
     "label": "Biometric residence permit (BRP) number",
-    "hint": "This must match what is on your BRP card. For example, RZ1234567"
+    "hint": "This must match what is on your BRP card. For example, ZU1234567"
   },
   "uan": {
     "label": "Unique application number (UAN)",


### PR DESCRIPTION
## What? 
[ACRS-14](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-14) Brp and dob details

## Why? 
To allow user enter a valid brp and dob 

## How? 
- Changed the fields label
- updated the not found page

## Testing?
tested locally 
## Screenshots (optional)
![Screenshot 2024-05-03 at 16 04 34](https://github.com/UKHomeOffice/acrs/assets/138882912/69d547a7-4e7b-4a58-8b59-6afa12856b48)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
