### PR TITLE
ACRS-39: Update hof-rds-api image to one with the latest migrations for DB verification

### DIFF
--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:bb5616719f0918afac470ad5a40c7b2505619b07
+          image: quay.io/ukhomeofficedigital/hof-rds-api:16bc712744851373e533d94ecf04724836be8247
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -33,7 +33,7 @@ spec:
       containers:
         - name: data-service
           # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:a42b5453fb9e0a4c158206e3e7b18753a228b5d0
+          image: quay.io/ukhomeofficedigital/hof-rds-api:bb5616719f0918afac470ad5a40c7b2505619b07
           imagePullPolicy: Always
           envFrom:
             - configMapRef:
@@ -46,7 +46,7 @@ spec:
             - name: SERVICE_NAME
               value: "acrs"
             - name: LATEST_MIGRATION
-              value: "20240419213237_acrs"
+              value: "20240502155941_add_verify_lookup_table"
             - name: MAX_PAYLOAD_SIZE
               value: "30mb"
             - name: REQUEST_TIMEOUT


### PR DESCRIPTION
## What? 

Update the hof-rds-api image to the latest pushed to quay. 
Update the LATEST_MIGRATION value in environment for the deployment to the latest created

## Why? 

See [ACRS-39](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-39).
This PR updates the RDS via a new migration adding a `verify_lookup` table (DOB, BRP, UAN). This will be pre-filled with verified users and will be queried at the point of user login to verify users of the form are genuine.

## How? 

[Added new migration in hof-rds-api](https://github.com/UKHomeOffice/hof-rds-api/pull/29). This generates a new image.
During deployment to the updated image as created above and configured in this PR the migration will run and new table will be added to RDS

## Testing?

Migrate and rollback tested locally ok.

## Anything Else? (optional)

Data to be added to RDS manually.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
