### PR TITLE
Acrs registry update : ACRS-37 - Replace quay with ECR registry

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ environment:
   # PRODUCTION_URL: TO BE UPDATED ONCE URL IS PROVIDED
   #IMAGE_URL: quay.io/ukhomeofficedigital
   #IMAGE_REPO: acrs
-  IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
+  #IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme
@@ -197,7 +197,7 @@ steps:
         from_secret: aws_secret_access_key
       region: eu-west-2
       repo: $${IMAGE_REPO}
-      registry: $${IMAGE_URL}
+      registry: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
       tags:
         - latest_${DRONE_BRANCH}
         - ${DRONE_COMMIT_SHA}

--- a/.drone.yml
+++ b/.drone.yml
@@ -180,7 +180,7 @@ steps:
         from_secret: DOCKER_PASSWORD
     commands:
       - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
-      - docker build --no-cache -t $${IMAGE_REPO,,}:$${DRONE_COMMIT_SHA} .
+      - docker build --no-cache -t ${IMAGE_REPO}:${DRONE_COMMIT_SHA} .
     volumes:
       - name: dockersock
         path: /var/run
@@ -196,7 +196,7 @@ steps:
       secret_key:
         from_secret: aws_secret_access_key
       region: eu-west-2
-      repo: $${IMAGE_REPO}
+      repo: ${IMAGE_REPO}
       registry: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
       tags:
         - latest_${DRONE_BRANCH}

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ environment:
   # PRODUCTION_URL: TO BE UPDATED ONCE URL IS PROVIDED
   #IMAGE_URL: quay.io/ukhomeofficedigital
   #IMAGE_REPO: acrs
-  #IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
+  IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
   IMAGE_REPO: sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ environment:
   #IMAGE_URL: quay.io/ukhomeofficedigital
   #IMAGE_REPO: acrs
   #IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
-  #IMAGE_REPO: sas/acrs  
+  IMAGE_REPO: sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme
   NON_PROD_AVAILABILITY: Mon-Sun 00:00-23:59 Europe/London

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,8 +10,10 @@ environment:
   UAT_ENV: sas-acrs-uat
   BRANCH_ENV: sas-acrs-branch
   # PRODUCTION_URL: TO BE UPDATED ONCE URL IS PROVIDED
-  IMAGE_URL: quay.io/ukhomeofficedigital
-  IMAGE_REPO: acrs
+  #IMAGE_URL: quay.io/ukhomeofficedigital
+  #IMAGE_REPO: acrs
+  IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
+  IMAGE_REPO: sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme
   NON_PROD_AVAILABILITY: Mon-Sun 00:00-23:59 Europe/London
@@ -137,9 +139,45 @@ steps:
   #       include:
   #         - master
   #     event: push
+  # ========
+  # - name: build_image
+  #   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  #   commands:
+  #     - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
+  #     - docker build --no-cache -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
+  #   volumes:
+  #     - name: dockersock
+  #       path: /var/run
+  #   when:
+  #     branch:
+  #       include:
+  #         - master
+  #         - feature/*
+  #     event: [push, pull_request]
 
+  # - name: image_to_quay
+  #   pull: if-not-exists
+  #   image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+  #   environment:
+  #     DOCKER_PASSWORD:
+  #       from_secret: DOCKER_PASSWORD
+  #   commands:
+  #   - docker login -u="ukhomeofficedigital+acrs" -p=$${DOCKER_PASSWORD} quay.io
+  #   - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
+  #   - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
+  #   when:
+  #     branch:
+  #       include:
+  #         - master
+  #         - feature/*
+  #     event: [push, pull_request]
+
+      
   - name: build_image
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: DOCKER_PASSWORD
     commands:
       - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
       - docker build --no-cache -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
@@ -147,27 +185,24 @@ steps:
       - name: dockersock
         path: /var/run
     when:
-      branch:
-        include:
-          - master
-          - feature/*
+      branch: master
       event: [push, pull_request]
 
-  - name: image_to_quay
-    pull: if-not-exists
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-    environment:
-      DOCKER_PASSWORD:
-        from_secret: DOCKER_PASSWORD
-    commands:
-    - docker login -u="ukhomeofficedigital+acrs" -p=$${DOCKER_PASSWORD} quay.io
-    - docker tag $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
-    - docker push $${IMAGE_URL}/$${IMAGE_REPO}:$${DRONE_COMMIT_SHA}
+  - name: image_to_ecr
+    image: plugins/ecr
+    settings:
+      access_key:
+        from_secret: aws_access_key_id
+      secret_key:
+        from_secret: aws_secret_access_key
+      region: eu-west-2
+      repo: $${IMAGE_REPO}
+      registry: $${IMAGE_URL}
+      tags:
+        - latest_${DRONE_BRANCH}
+        - ${DRONE_COMMIT_SHA}
     when:
-      branch:
-        include:
-          - master
-          - feature/*
+      branch: master
       event: [push, pull_request]
 
   # Trivy Security Scannner

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ environment:
   #IMAGE_URL: quay.io/ukhomeofficedigital
   #IMAGE_REPO: acrs
   #IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
-  IMAGE_REPO: /sas/acrs  
+  IMAGE_REPO: sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme
   NON_PROD_AVAILABILITY: Mon-Sun 00:00-23:59 Europe/London
@@ -196,7 +196,8 @@ steps:
       secret_key:
         from_secret: aws_secret_access_key
       region: eu-west-2
-      repo: ${IMAGE_REPO}
+      #repo: ${IMAGE_REPO}
+      repo: sas/acrs 
       registry: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
       tags:
         - latest_${DRONE_BRANCH}

--- a/.drone.yml
+++ b/.drone.yml
@@ -206,7 +206,7 @@ steps:
       branch: master
       event: [push, pull_request]
 
-  # Trivy Security Scannner
+  ## Trivy Security Scannner
   - name: scan-image
     pull: always
     image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/trivy/client:latest

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ environment:
   #IMAGE_URL: quay.io/ukhomeofficedigital
   #IMAGE_REPO: acrs
   #IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
-  IMAGE_REPO: sas/acrs  
+  #IMAGE_REPO: sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme
   NON_PROD_AVAILABILITY: Mon-Sun 00:00-23:59 Europe/London

--- a/.drone.yml
+++ b/.drone.yml
@@ -180,7 +180,7 @@ steps:
         from_secret: DOCKER_PASSWORD
     commands:
       - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
-      - docker build --no-cache -t ${IMAGE_REPO}:${DRONE_COMMIT_SHA} .
+      - docker build --no-cache -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
     volumes:
       - name: dockersock
         path: /var/run

--- a/.drone.yml
+++ b/.drone.yml
@@ -215,7 +215,7 @@ steps:
         cpu: 1000
         memory: 1024Mi
     environment:
-      IMAGE_NAME: acrs:${DRONE_COMMIT_SHA}
+      IMAGE_NAME: sas/acrs:${DRONE_COMMIT_SHA}
       SEVERITY: MEDIUM,HIGH,CRITICAL
       FAIL_ON_DETECTION: false
       IGNORE_UNFIXED: true

--- a/.drone.yml
+++ b/.drone.yml
@@ -180,7 +180,7 @@ steps:
         from_secret: DOCKER_PASSWORD
     commands:
       - n=0; while [ "$n" -lt 60 ] && [ ! docker stats --no-stream ]; do n=$(( n + 1 )); sleep 1; done
-      - docker build --no-cache -t $${IMAGE_REPO}:$${DRONE_COMMIT_SHA} .
+      - docker build --no-cache -t $${IMAGE_REPO,,}:$${DRONE_COMMIT_SHA} .
     volumes:
       - name: dockersock
         path: /var/run

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ environment:
   #IMAGE_URL: quay.io/ukhomeofficedigital
   #IMAGE_REPO: acrs
   #IMAGE_URL: 340268328991.dkr.ecr.eu-west-2.amazonaws.com
-  IMAGE_REPO: sas/acrs  
+  IMAGE_REPO: /sas/acrs  
   GIT_REPO: UKHomeOffice/acrs
   HOF_CONFIG: hof-services-config/Afghan_Citizens_Resettlement_Scheme
   NON_PROD_AVAILABILITY: Mon-Sun 00:00-23:59 Europe/London


### PR DESCRIPTION
## What? 
We are updating the Image registry. Quay repository is being replaced with Amazon ECR
 
## Why? 
Quay has security risks because it is a public repository and could be accessed by the public. Amazon ECR is a private registry and hence more secure.

## How? 
- Drone.yaml has been updated with yaml for ECR added to the pipeline steps
- The yaml for quay has been replaced with ecr's yaml 
- The AWS secrets to access aws and push the image to ecr has been added to Drone CI UI
- This branch is merged to master and then tested  
## Testing?
- Several commits and PR will be raised to to test the pipeline
- 
## Screenshots (optional)

![image](https://github.com/UKHomeOffice/acrs/assets/162344062/cf590e45-029f-47dd-bdf4-3351193ba428)


## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
