### PR TITLE
ACRS-14 Fix dob field hint

### DIFF
--- a/apps/verify/behaviours/get-dob-field-hint.js
+++ b/apps/verify/behaviours/get-dob-field-hint.js
@@ -1,0 +1,9 @@
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const locals = super.locals(req, res);
+    if (req.form.options.route === '/sign-in-brp') {
+      req.form.values['brp-hint'] = 'This must match what is on your BRP card. ';
+    }
+    return locals;
+  }
+};

--- a/apps/verify/index.js
+++ b/apps/verify/index.js
@@ -1,6 +1,7 @@
 'use strict';
 const ValidateCaseDetails = require('./behaviours/validate-case-details');
 const SendVerificationEmail = require('./behaviours/send-verification-email');
+const GetDobFieldHint = require('./behaviours/get-dob-field-hint');
 
 module.exports = {
   name: 'verify',
@@ -20,7 +21,7 @@ module.exports = {
       next: '/sign-in-brp'
     },
     '/sign-in-brp': {
-      behaviours: [ValidateCaseDetails],
+      behaviours: [GetDobFieldHint, ValidateCaseDetails],
       fields: ['brp', 'date-of-birth'],
       backLink: 'sign-in',
       next: '/sign-in-email'
@@ -29,7 +30,7 @@ module.exports = {
       backLink: 'sign-in-brp'
     },
     '/sign-in-uan': {
-      behaviours: [ValidateCaseDetails],
+      behaviours: [GetDobFieldHint, ValidateCaseDetails],
       fields: ['uan', 'date-of-birth'],
       backLink: 'sign-in',
       next: '/sign-in-email'

--- a/apps/verify/translations/src/en/fields.json
+++ b/apps/verify/translations/src/en/fields.json
@@ -8,7 +8,7 @@
       },
       "uan": {
         "label": "Using a UAN",
-        "hint": "For example, 1111-2222-3333-4444"
+        "hint": "For example, 1234-1234-1234-1234"
       }
     }
   },
@@ -22,7 +22,7 @@
   },
   "date-of-birth": {
     "legend": "Date of birth",
-    "hint": "For example, 27 3 1985"
+    "hint": "{{values.brp-hint}}For example, 27 3 1985"
   },
   "user-email": {
     "hint": "We will email you a secure link, so you can save your information and return later."


### PR DESCRIPTION
## What? 

Add a dynamic hint for the `date-of-birth` field between the `/sign-in-brp` and `/sign-in-uan` pages.

## Why? 

Both pages have a date of birth field that is the same datapoint and can be saved to session as the same value. however the message hint for BRP has more text than the one for UAN.

## How? 

Adds a behaviour that works out if we are on the `/sign-in-brp` page and if it is it will add the extra text to the date of birth field hint

## Testing?

Tested locally 

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
