### PR TITLE
ACRS-52: Add Are you referring a parent to come to the UK? page

### DIFF
--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -44,9 +44,7 @@ module.exports = {
     mixin: 'radio-group',
     options: ['yes', 'no'],
     validate: 'required',
-    legend: {
-      className: 'visuallyhidden'
-    }
+    isPageHeading: true
   },
   'brother-or-sister': {
     mixin: 'radio-group',

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -100,6 +100,7 @@ module.exports = {
     // Figma Section: "Who are you applying to bring to the UK? Sponsor under 18" (who-bringing-parent)
 
     '/parent': {
+      behaviours: SaveFormSession,
       fields: ['parent'],
       forks: [{
         target: '/brother-or-sister',
@@ -108,7 +109,9 @@ module.exports = {
           value: 'no'
         }
       }],
-      next: '/parent-details'
+      next: '/parent-details',
+      locals: { showSaveAndExit: true },
+      continueOnEdit: true
     },
 
     '/parent-details': {

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -61,13 +61,14 @@
       }
   },
   "parent": {
-      "label": "SKELETON: parent",
+      "legend": "Are you referring a parent to come to the UK?",
+      "hint": "You can only refer your own parents. You can refer a maximum of 2 parents",
       "options": {
         "yes": {
-          "label": "SKELETON: Yes"
+          "label": "Yes"
         },
         "no": {
-          "label": "SKELETON: No"
+          "label": "No"
         }
       }
   },

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -42,9 +42,6 @@
   "your-address": {
     "header": "SKELETON: /your-address"
   },
-  "parent": {
-    "header": "SKELETON: /parent"
-  },
   "parent-details": {
     "header": "SKELETON: /parent-details"
   },

--- a/apps/acrs/translations/src/en/validation.json
+++ b/apps/acrs/translations/src/en/validation.json
@@ -1,15 +1,15 @@
 {
     "who-is-completing-form": {
-        "required": "You must select an option"
+      "required": "You must select an option"
     },
     "full-name": {
-        "required": "You must select an option"
+      "required": "You must select an option"
     },
     "confirm-referrer-email": {
-        "required": "You must select an option"
+      "required": "You must select an option"
     },
     "parent": {
-        "required": "You must select an option"
+      "required": "You must select an option"
     },
     "brother-or-sister": {
         "required": "You must select an option"


### PR DESCRIPTION
## What? 

[ACRS-52](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-52)

Adds the "Are you referring a parent to come to the UK?" page to the form. 
Adds step, field, validations and copy text.

## Why? 

This page is required in the ACRS form. The page is within a conditional block, but does not have any conditional logic of its own except for the forking from the next step.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
