### PR TITLE
ACRS-48 confirm referrer email

### DIFF
--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -96,7 +96,9 @@ module.exports = {
           value: 'no'
         }
       }],
-      next: '/provide-telephone-number'
+      next: '/provide-telephone-number',
+      behaviours: SaveFormSession,
+      locals: { showSaveAndExit: true }
     },
 
     '/referrer-email': {

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -24,13 +24,12 @@
     "hint": "You can copy this from your biometric residence permit card or any letters from the Home Office"
   },
   "confirm-referrer-email": {
-      "label": "SKELETON: confirm-referrer-email",
       "options": {
         "yes": {
-          "label": "SKELETON: Yes"
+          "label": "Yes"
         },
         "no": {
-          "label": "SKELETON: No"
+          "label": "No"
         }
       }
   },

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -64,7 +64,8 @@
     "header": "SKELETON: /complete-as-referrer"
   },
   "confirm-referrer-email": {
-    "header": "SKELETON: /confirm-referrer-email"
+    "header": "Is this {{values.full-name}}’s email address?",
+    "paragraph": "We may use this email address to contact them for more information about the referral."
   },
   "referrer-email": {
     "header": "SKELETON: /referrer-email"

--- a/apps/acrs/views/confirm-referrer-email.html
+++ b/apps/acrs/views/confirm-referrer-email.html
@@ -1,0 +1,8 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p class="bold">{{#t}}{{values.user-email}}{{/t}}</p>
+    <p class="govuk-hint">{{#t}}pages.confirm-referrer-email.paragraph{{/t}}</p>
+    {{#radio-group}}confirm-referrer-email{{/radio-group}}
+    {{#input-submit}}save-and-continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/acrs/views/confirm-referrer-email.html
+++ b/apps/acrs/views/confirm-referrer-email.html
@@ -3,6 +3,6 @@
     <p class="bold">{{#t}}{{values.user-email}}{{/t}}</p>
     <p class="govuk-hint">{{#t}}pages.confirm-referrer-email.paragraph{{/t}}</p>
     {{#radio-group}}confirm-referrer-email{{/radio-group}}
-    {{#input-submit}}save-and-continue{{/input-submit}}
+    {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
What?

[ACRS-48 - Is this referrers email](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-48)
Add the `/confirm-referrer-email` page to the `acrs/` steps

Why?

The `/confirm-referrer-email` page is a requirement of the flow.
