### PR TITLE
ACRS-20 : Changed external ingress in prod to internal ingress and added staging env

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -407,7 +407,7 @@ steps:
       branch: master
       event: push
 
-  # Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
+  ## Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod
     pull: if-not-exists
     image: drone/cli:alpine@sha256:14409f7f7247befb9dd2effdb2f61ac40d1f5fbfb1a80566cf6f2f8d21f3be11

--- a/.drone.yml
+++ b/.drone.yml
@@ -392,20 +392,20 @@ steps:
       branch: master
       event: push
 
-  #  Deploy to Staging environment
-  # - name: deploy_to_stg
-  #   pull: if-not-exists
-  #   image: quay.io/ukhomeofficedigital/kd:v1.14.0
-  #   environment:
-  #     KUBE_SERVER:
-  #       from_secret: kube_server_prod
-  #     KUBE_TOKEN:
-  #       from_secret: kube_token_prod
-  #   commands:
-  #     - bin/deploy.sh $${STG_ENV}
-  #   when:
-  #     branch: master
-  #     event: push
+   Deploy to Staging environment
+  - name: deploy_to_stg
+    pull: if-not-exists
+    image: quay.io/ukhomeofficedigital/kd:v1.14.0
+    environment:
+      KUBE_SERVER:
+        from_secret: kube_server_prod
+      KUBE_TOKEN:
+        from_secret: kube_token_prod
+    commands:
+      - bin/deploy.sh $${STG_ENV}
+    when:
+      branch: master
+      event: push
 
   # Checks a build being promoted has passed, is on master which effectively means a healthy build on Staging
   - name: sanity_check_build_prod

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,7 +5,7 @@ export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yam
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
-export DATA_SERVICE_INTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-external-annotations.yaml
+export DATA_SERVICE_INTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-internal-annotations.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml
 

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,7 +5,7 @@ export INGRESS_INTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-internal-annotations.yam
 export INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/ingress-external-annotations.yaml
 export CONFIGMAP_VALUES=$HOF_CONFIG/configmap-values.yaml
 export NGINX_SETTINGS=$HOF_CONFIG/nginx-settings.yaml
-export DATA_SERVICE_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-external-annotations.yaml
+export DATA_SERVICE_INTERNAL_ANNOTATIONS=$HOF_CONFIG/data-service-external-annotations.yaml
 export FILEVAULT_NGINX_SETTINGS=$HOF_CONFIG/filevault-nginx-settings.yaml
 export FILEVAULT_INGRESS_EXTERNAL_ANNOTATIONS=$HOF_CONFIG/filevault-ingress-external-annotations.yaml
 

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -24,7 +24,7 @@ spec:
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
       secretName: branch-tls-internal
-      {{ else }} 
+      {{ else }}
       secretName: data-service-cert-cmio
       {{ end }}
   rules:

--- a/kube/hof-rds-api/ingress.yml
+++ b/kube/hof-rds-api/ingress.yml
@@ -7,13 +7,13 @@ metadata:
   {{ else }}
   name: data-service
   {{ end }}
-{{ file .DATA_SERVICE_EXTERNAL_ANNOTATIONS | indent 2 }}
+{{ file .DATA_SERVICE_INTERNAL_ANNOTATIONS | indent 2 }}
 spec:
-  ingressClassName: nginx-external
+  ingressClassName: nginx-internal
   tls:
     - hosts:
       {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-        # - TO BE UPDATED ONCE URL IS PROVIDED
+        - acrs-data-service.internal.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
         - acrs-data-service.stg.sas.homeoffice.gov.uk
       {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}
@@ -23,13 +23,13 @@ spec:
         - data-service-{{ .DRONE_SOURCE_BRANCH }}.branch.sas-notprod.homeoffice.gov.uk
       {{ end }}
       {{ if eq .KUBE_NAMESPACE .BRANCH_ENV }}
-      secretName: branch-tls-external
-      {{ else }}
+      secretName: branch-tls-internal
+      {{ else }} 
       secretName: data-service-cert-cmio
       {{ end }}
   rules:
     {{ if eq .KUBE_NAMESPACE .PROD_ENV }}
-    # - host: TO BE UPDATED ONCE URL IS PROVIDED
+    - acrs-data-service.internal.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .STG_ENV }}
     - host: acrs-data-service.stg.sas.homeoffice.gov.uk
     {{ else if eq .KUBE_NAMESPACE .UAT_ENV }}


### PR DESCRIPTION
## What? 

Changing external ingress for prod env in acrs to internal ingress
Also added the staging environment in the pipeline

## Why? 

This ingress is used for internal communication between pods and services and not from the browser
Staging is added to be able to deploy to staging environment 

## How? 
For prod in ingress.yaml, the external ingresses have been changed to internal ingress 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ x] I have created a JIRA number for my branch
- [ x] I have created a JIRA number for my commit
- [x ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x ] Ensure drone builds are green especially tests
- [x ] I will squash the commits before merging
