### PR TITLE
ACRS-41 Set up parent-details page

### DIFF
--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -61,7 +61,7 @@ module.exports = {
   'parent-phone-number': {
     labelClassName: 'bold',
     validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: [250] }],
-    className: ['govuk-input', 'govuk-!-width-two-thirds']
+    className: ['govuk-input', 'govuk-!-width-one-half']
   },
   'parent-email': {
     labelClassName: 'bold',
@@ -75,7 +75,7 @@ module.exports = {
     labelClassName: 'bold',
     mixin: 'select',
     validate: ['required', isInCountriesList],
-    className: ['typeahead', 'js-hidden'],
+    className: ['js-hidden'],
     options: [
       {
         value: '',

--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -1,5 +1,11 @@
 'use strict';
 
+const _ = require('lodash');
+const dateComponent = require('hof').components.date;
+const after1900Validator = { type: 'after', arguments: ['1900'] };
+const countries = require('hof').utils.countries().concat([{ value: 'Unknown', label: 'Unknown' }]);
+const isInCountriesList = value => countries.some(country => country.value === value);
+
 module.exports = {
   'who-completing-form': {
     isPageHeading: true,
@@ -47,6 +53,46 @@ module.exports = {
     legend: {
       className: 'visuallyhidden'
     }
+  },
+  'parent-full-name': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'bold'
+  },
+  'parent-phone-number': {
+    labelClassName: 'bold',
+    validate: ['internationalPhoneNumber', { type: 'maxlength', arguments: [250] }],
+    className: ['govuk-input', 'govuk-!-width-two-thirds']
+  },
+  'parent-email': {
+    labelClassName: 'bold',
+    validate: ['email']
+  },
+  'parent-date-of-birth': dateComponent('parent-date-of-birth', {
+    legend: { className: 'bold' },
+    validate: ['required', 'before', after1900Validator]
+  }),
+  'parent-country': {
+    labelClassName: 'bold',
+    mixin: 'select',
+    validate: ['required', isInCountriesList],
+    className: ['typeahead', 'js-hidden'],
+    options: [
+      {
+        value: '',
+        label: 'fields.parent-country.options.null'
+      }
+    ].concat(_.sortBy(countries, o => o.label))
+  },
+  'parent-evacuated-without-reason': {
+    labelClassName: 'bold',
+    mixin: 'textarea',
+    attributes: [{ attribute: 'rows', value: 5 }],
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'regex', arguments: /^[^\[\]\|<>]*$/ },
+      { type: 'maxlength', arguments: 15000 }
+    ]
   },
   'brother-or-sister': {
     mixin: 'radio-group',

--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -135,5 +135,6 @@ module.exports = {
     legend: {
       className: 'visuallyhidden'
     }
-  }
+  },
+  isInCountriesList
 };

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -124,8 +124,17 @@ module.exports = {
     },
 
     '/parent-details': {
-      fields: [],
-      next: '/parent-summary'
+      behaviours: SaveFormSession,
+      fields: [
+        'parent-full-name',
+        'parent-phone-number',
+        'parent-email',
+        'parent-date-of-birth',
+        'parent-country',
+        'parent-evacuated-without-reason'
+      ],
+      next: '/parent-summary',
+      locals: { showSaveAndExit: true },
     },
     '/parent-summary': {
       fields: [],

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -134,7 +134,7 @@ module.exports = {
         'parent-evacuated-without-reason'
       ],
       next: '/parent-summary',
-      locals: { showSaveAndExit: true },
+      locals: { showSaveAndExit: true }
     },
     '/parent-summary': {
       fields: [],

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -74,6 +74,30 @@
         }
       }
   },
+  "parent-full-name": {
+    "label": "Parent's full name"
+  },
+  "parent-phone-number": {
+    "label": "Parent's telephone number (optional)",
+    "hint": "For international numbers include the country code"
+  },
+  "parent-email": {
+    "label": "Parent's email address (optional)"
+  },
+  "parent-date-of-birth": {
+    "legend": "Parent's date of birth",
+    "hint": "For example, 27 3 1988. If they do not have a date of birth, enter a date that matches any evidence"
+  },
+  "parent-country": {
+    "label": "What country do they live in?",
+    "hint": "Start to type the country and options will appear. Select 'Unknown' if you do not know",
+    "options": {
+      "null": "Select a country"
+    }
+  },
+  "parent-evacuated-without-reason": {
+    "label": "Why were you evacuated without this parent?"
+  },
   "brother-or-sister": {
       "label": "SKELETON: brother-or-sister",
       "options": {

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -37,7 +37,7 @@
         "label": "Full name"
       },
       "confirm-referrer-email": {
-        "": "Email"
+        "label": "Email"
       },
       "legal-representative-email": {
         "label": "Email"
@@ -51,7 +51,6 @@
       "current-email": {
         "label": "Email"
       }
-    
     }
   },
   "immigration-adviser-details": {
@@ -82,7 +81,8 @@
     "header": "SKELETON: /parent"
   },
   "parent-details": {
-    "header": "SKELETON: /parent-details"
+    "header": "Parent {{values.parentCount}} details",
+    "paragraph": "Add your parents one at a time."
   },
   "parent-summary": {
     "header": "SKELETON: /parent-summary"

--- a/apps/acrs/translations/src/en/validation.json
+++ b/apps/acrs/translations/src/en/validation.json
@@ -14,6 +14,31 @@
     "parent": {
         "required": "You must select an option"
     },
+    "parent-full-name": {
+      "required": "Enter this parent's full name",
+      "notUrl": "Please do not enter a link/url into your answers"
+    },
+    "parent-phone-number": {
+      "internationalPhoneNumber": "Enter a valid phone number"
+    },
+    "parent-email": {
+      "email": "Enter a valid email address"
+    },
+    "parent-date-of-birth": {
+      "required": "Enter this parent's date of birth",
+      "date": "Please enter a valid date",
+      "after": "Enter a date after 01 01 1900",
+      "before": "Please enter a date in the past"
+    },
+    "parent-country": {
+      "required": "Enter the country this parent lives in",
+      "isInCountriesList": "You must choose a country from the provided list"
+    },
+    "parent-evacuated-without-reason": {
+      "required": "Enter the reason you were evacuated without this parent",
+      "regex": "Explanation must be 15,000 characters or less and must not include [ ] < > / |",
+      "notUrl": "Please do not enter a link/url into your answers"
+    },
     "brother-or-sister": {
         "required": "You must select an option"
     },

--- a/apps/acrs/views/parent-details.html
+++ b/apps/acrs/views/parent-details.html
@@ -1,0 +1,10 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p>{{#t}}pages.parent-details.paragraph{{/t}}</p>
+    <br>
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/verify/behaviours/send-verification-email.js
+++ b/apps/verify/behaviours/send-verification-email.js
@@ -10,6 +10,7 @@ const templateId = config.govukNotify.userAuthTemplateId;
 const baseUrl = `${config.saveService.host}:${config.saveService.port}/saved_applications`;
 const tokenGenerator = require('../../../db/save-token');
 const _ = require('lodash');
+const { error } = require('jquery');
 
 const getPersonalisation = (host, token, idType) => {
   const protocol = host.includes('localhost') ? 'http' : 'https';
@@ -88,10 +89,13 @@ module.exports = superclass => class extends superclass {
     const token = tokenGenerator.save(req, email);
 
     try {
-      await notifyClient.sendEmail(templateId, email, {
+      const response = await notifyClient.sendEmail(templateId, email, {
         personalisation: getPersonalisation(host, token, idType)
       });
+      console.log('RESPONSE: ', response.status);
     } catch (e) {
+      console.log('ERROR: ', e.status);
+      console.log('E MESSAGE: ', e.message);
       return next(e);
     }
 

--- a/apps/verify/behaviours/send-verification-email.js
+++ b/apps/verify/behaviours/send-verification-email.js
@@ -10,7 +10,6 @@ const templateId = config.govukNotify.userAuthTemplateId;
 const baseUrl = `${config.saveService.host}:${config.saveService.port}/saved_applications`;
 const tokenGenerator = require('../../../db/save-token');
 const _ = require('lodash');
-const { error } = require('jquery');
 
 const getPersonalisation = (host, token, idType) => {
   const protocol = host.includes('localhost') ? 'http' : 'https';
@@ -89,13 +88,10 @@ module.exports = superclass => class extends superclass {
     const token = tokenGenerator.save(req, email);
 
     try {
-      const response = await notifyClient.sendEmail(templateId, email, {
+      await notifyClient.sendEmail(templateId, email, {
         personalisation: getPersonalisation(host, token, idType)
       });
-      console.log('RESPONSE: ', response.status);
     } catch (e) {
-      console.log('ERROR: ', e.status);
-      console.log('E MESSAGE: ', e.message);
       return next(e);
     }
 

--- a/test/_unit/custom-validations.spec.js
+++ b/test/_unit/custom-validations.spec.js
@@ -1,0 +1,19 @@
+const countries = require('hof').utils.countries().concat([{ value: 'Unknown', label: 'Unknown' }]);
+const isInCountriesList = value => countries.some(country => country.value === value);
+
+describe('Validation', () => {
+  describe('isInCountriesList', () => {
+    it('Returns true for a country in the list', () => {
+      expect(isInCountriesList('Unknown')).to.equal(true);
+    });
+
+    it('Returns false for a country not in the list', () => {
+      expect(isInCountriesList('Nowhere')).to.equal(false);
+    });
+
+    it('Returns false for an incorrect type of value', () => {
+      expect(isInCountriesList(undefined)).to.equal(false);
+    });
+
+  });
+});

--- a/test/_unit/custom-validations.spec.js
+++ b/test/_unit/custom-validations.spec.js
@@ -14,6 +14,5 @@ describe('Validation', () => {
     it('Returns false for an incorrect type of value', () => {
       expect(isInCountriesList(undefined)).to.equal(false);
     });
-
   });
 });

--- a/test/_unit/custom-validations.spec.js
+++ b/test/_unit/custom-validations.spec.js
@@ -1,5 +1,4 @@
-const countries = require('hof').utils.countries().concat([{ value: 'Unknown', label: 'Unknown' }]);
-const isInCountriesList = value => countries.some(country => country.value === value);
+const { isInCountriesList } = require('../../apps/acrs/fields/index')
 
 describe('Validation', () => {
   describe('isInCountriesList', () => {

--- a/test/_unit/custom-validations.spec.js
+++ b/test/_unit/custom-validations.spec.js
@@ -1,4 +1,4 @@
-const { isInCountriesList } = require('../../apps/acrs/fields/index')
+const { isInCountriesList } = require('../../apps/acrs/fields/index');
 
 describe('Validation', () => {
   describe('isInCountriesList', () => {


### PR DESCRIPTION
## What? 

[ACRS-41](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-41)
Adds the Steps fields, view and validations for the '/parent-details' page.
Adds a few unit tests for the custom validator added.

## Why?

Parent details are added in an aggregator format up to a limit of two parents. These fields are those that are added to the aggregator with each parent.

Aggregation will be added with the '/parent-summary' page.

## Testing?

Page and validations work locally. New tests passing locally.

## Anything Else? (optional)

There is some logic that needs to add a number into the title of this page (the number of parents added so far in the aggregator to a limit of 2). As the aggregator code will be added with the parent-summary page this information is only placeholder code for now and no number is added to the page in the relevant spot.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
