### PR TITLE
ACRS-102: Fix bug - Add validation message for invalid non-email entry into field

### DIFF
--- a/apps/verify/translations/src/en/validation.json
+++ b/apps/verify/translations/src/en/validation.json
@@ -20,6 +20,7 @@
   },
   "user-email": {
     "required": "Enter your email address",
-    "noRecordMatch": "Your email does not match the other details given. Please enter the correct email"
+    "noRecordMatch": "Your email does not match the other details given. Please enter the correct email",
+    "email": "Enter a valid email address"
   }
 }


### PR DESCRIPTION
## What? 

[ACRS-102](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-102)
Add a validation message for cases where non-email format entries are made into the verify app's user-email field.

## Why?

Without the validation message there is no context given to the user after an incorrectly formatted entry into this field for example a URL or other non-email format text

## How? 

Update validation messages for the verify app in the user-email field.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
