### PR TITLE
Comment out text that may be breaking pipeline config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -392,7 +392,7 @@ steps:
       branch: master
       event: push
 
-   Deploy to Staging environment
+  #  Deploy to Staging environment
   - name: deploy_to_stg
     pull: if-not-exists
     image: quay.io/ukhomeofficedigital/kd:v1.14.0


### PR DESCRIPTION
## What? 

Comment out a line in the drone.yml file.

## Why? 

This text is not functional and should be a comment. It is possible that uncommented this is breaking the config and causing drone builds to fail before they start.

## Testing?

This will be tested by the pipeline succeeding from this PR branch
