### PR TITLE
ACRS: 84, 94, 60, 101 - Add Additional family initial pages over-18/under-18 routes

### DIFF
--- a/apps/acrs/behaviours/locals-18-flag.js
+++ b/apps/acrs/behaviours/locals-18-flag.js
@@ -1,0 +1,10 @@
+const { isOver18 } = require('../../../lib/utilities');
+
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const locals = Object.assign({}, super.locals(req, res), {
+      over18: isOver18(req.sessionModel.get('date-of-birth'))
+    });
+    return locals;
+  }
+};

--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -175,12 +175,10 @@ module.exports = {
     }
   },
   'additional-family': {
+    legend: { className: 'bold' },
     mixin: 'radio-group',
     options: ['yes', 'no'],
-    validate: 'required',
-    legend: {
-      className: 'visuallyhidden'
-    }
+    validate: 'required'
   },
   'no-family-referred': {
     // SKELETON: for the purposes of the Skeleton this page is used to determine

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -7,7 +7,7 @@ const CheckEmailToken = require('./behaviours/check-email-token');
 const SaveFormSession = require('./behaviours/save-form-session');
 const SaveAndExit = require('./behaviours/save-and-exit');
 const Utilities = require('../../lib/utilities');
-const locals18Flag = require('./behaviours/locals-18-flag');
+const Locals18Flag = require('./behaviours/locals-18-flag');
 
 module.exports = {
   name: 'acrs',
@@ -264,7 +264,7 @@ module.exports = {
     // Figma Section: "Additional family members" (additional-family)
 
     '/additional-family': {
-      behaviours: [SaveFormSession, locals18Flag],
+      behaviours: [SaveFormSession, Locals18Flag],
       fields: ['additional-family'],
       forks: [
         {
@@ -301,7 +301,7 @@ module.exports = {
       next: '/family-in-uk'
     },
     '/no-family-referred': {
-      behaviours: locals18Flag
+      behaviours: Locals18Flag
     },
 
     // Figma Section: "Family members that live in the UK" (family-uk)

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -264,27 +264,21 @@ module.exports = {
               return (req.sessionModel.get('partner') === 'no' &&
                 req.sessionModel.get('children') === 'no' &&
                 req.sessionModel.get('additional-family') === 'no');
-            } else {
-              return (req.sessionModel.get('parent') === 'no' &&
-                req.sessionModel.get('brother-or-sister') === 'no' &&
-                req.sessionModel.get('additional-family') === 'no');
             }
+            return (req.sessionModel.get('parent') === 'no' &&
+              req.sessionModel.get('brother-or-sister') === 'no' &&
+              req.sessionModel.get('additional-family') === 'no');
           }
         },
         {
-          target: '/family-in-uk',
-          condition: req => {
-            if (Utilities.isOver18(req.sessionModel.get('date-of-birth'))) {
-              return (req.sessionModel.get('partner') === 'yes' ||
-                req.sessionModel.get('children') === 'yes');
-            } else {
-              return (req.sessionModel.get('parent') === 'yes' ||
-                req.sessionModel.get('brother-or-sister') === 'yes');
-            }
+          target: '/additional-family-details',
+          condition: {
+            field: 'additional-family',
+            value: 'yes'
           }
         }
       ],
-      next: '/additional-family-details',
+      next: '/family-in-uk',
       locals: { showSaveAndExit: true }
     },
 

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -193,24 +193,13 @@
       }
   },
   "additional-family": {
-      "label": "SKELETON: additional-family",
-      "options": {
-        "yes": {
-          "label": "SKELETON: Yes"
-        },
-        "no": {
-          "label": "SKELETON: No"
-        }
-      }
-  },
-  "no-family-referred": {
-    "label": "SKELETON: no-family-referred",
+    "legend": "Are you referring additional family members to come to the UK?",
     "options": {
-      "under-18": {
-        "label": "SKELETON: Referrer DOB < 28-09-2023 (under 18)"
+      "yes": {
+        "label": "Yes"
       },
-      "over-18": {
-        "label": "SKELETON: Referrer DOB >= 28-09-2023 (over 18)"
+      "no": {
+        "label": "No"
       }
     }
   },

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -148,13 +148,31 @@
     "header": "SKELETON: /child-details-2"
   },
   "additional-family": {
-    "header": "SKELETON: /additional-family"
+    "header": "Additional family members",
+    "paragraph-1": "Additional family member means anyone who is not:",
+    "list": {
+      "over-18": {
+        "item-1": "your husband or wife (spouse), or unmarried partner",
+        "item-2": "your own child"
+      },
+      "uber-18": ["your husband or wife (spouse), or unmarried partner", "your own child"],
+      "under-18": {
+        "item-1": "your parents",
+        "item-2": "your brothers or sisters"
+      }
+    },
+    "paragraph-2": "You must only refer additional family members to come to the UK in",
+    "link-text": "exceptional circumstances",
+    "paragraph-3": "You must have evidence to prove the exceptional circumstances."
   },
   "additional-family-details": {
     "header": "SKELETON: /additional-family-details"
   },
   "no-family-referred": {
-    "header": "SKELETON: /no-family-referred"
+    "header": "You must refer a family member",
+    "paragraph-1": "You have told us you are not referring any family members.",
+    "paragraph-2": "If you are not referring a family member, you do not need to use this form.",
+    "link-text": "Return and refer a family member"
   },
   "who-is-responsible": {
     "header": "SKELETON: /who-is-responsible"

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -155,7 +155,6 @@
         "item-1": "your husband or wife (spouse), or unmarried partner",
         "item-2": "your own child"
       },
-      "uber-18": ["your husband or wife (spouse), or unmarried partner", "your own child"],
       "under-18": {
         "item-1": "your parents",
         "item-2": "your brothers or sisters"

--- a/apps/acrs/translations/src/en/validation.json
+++ b/apps/acrs/translations/src/en/validation.json
@@ -98,9 +98,6 @@
     "additional-family": {
       "required": "You must select an option"
     },
-    "no-family-referred": {
-      "required": "You must select an option"
-    },
     "family-in-uk": {
       "required": "You must select an option"
     },

--- a/apps/acrs/views/additional-family.html
+++ b/apps/acrs/views/additional-family.html
@@ -13,8 +13,7 @@
     </ul>
     <p class="govuk-body">
       {{#t}}pages.additional-family.paragraph-2{{/t}}
-      <a href="">{{#t}}pages.additional-family.link-text{{/t}}</a>
-      .
+      <a href=""> {{#t}}pages.additional-family.link-text{{/t}}</a>.
     </p>
     <p class="govuk-body">{{#t}}pages.additional-family.paragraph-3{{/t}}</p>
     {{#renderField}}additional-family{{/renderField}}

--- a/apps/acrs/views/additional-family.html
+++ b/apps/acrs/views/additional-family.html
@@ -1,0 +1,23 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p class="govuk-body">{{#t}}pages.additional-family.paragraph-1{{/t}}</p>
+    <ul class="govuk-list govuk-list--bullet">
+      {{#over18}}
+        <li>{{#t}}pages.additional-family.list.over-18.item-1{{/t}}</li>
+        <li>{{#t}}pages.additional-family.list.over-18.item-2{{/t}}</li>
+      {{/over18}}
+      {{^over18}}
+        <li>{{#t}}pages.additional-family.list.under-18.item-1{{/t}}</li>
+        <li>{{#t}}pages.additional-family.list.under-18.item-2{{/t}}</li>
+      {{/over18}}
+    </ul>
+    <p class="govuk-body">
+      {{#t}}pages.additional-family.paragraph-2{{/t}}
+      <a href="">{{#t}}pages.additional-family.link-text{{/t}}</a>
+      .
+    </p>
+    <p class="govuk-body">{{#t}}pages.additional-family.paragraph-3{{/t}}</p>
+    {{#renderField}}additional-family{{/renderField}}
+    {{#input-submit}}continue-only{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/acrs/views/no-family-referred.html
+++ b/apps/acrs/views/no-family-referred.html
@@ -1,0 +1,18 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p class="govuk-body">{{#t}}pages.no-family-referred.paragraph-1{{/t}}</p>
+    <p class="govuk-body">{{#t}}pages.no-family-referred.paragraph-2{{/t}}</p>
+    <p class="govuk-body">
+      {{#over18}}
+      <a href="/acrs/partner">
+        {{#t}}pages.no-family-referred.link-text{{/t}}
+      </a>
+    {{/over18}}
+    {{^over18}}
+      <a href="/acrs/parent">
+        {{#t}}pages.no-family-referred.link-text{{/t}}
+      </a>
+    {{/over18}}
+    </p>
+  {{/page-content}}
+{{/partials-page}}


### PR DESCRIPTION
## What? 

[ACRS-84](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-84)
[ACRS-94](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-94)
[ACRS-60](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-60)
[ACRS-101](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-101)

Adds the 'do you want to refer additional family members (i.e. not parents, siblings, partners or direct children depending on age) pages for both over-18 and under-18 (18 cut off being 2003-08-23 for the sake of this form).

Adds the logic for additional warning message page with return link for if a person seemingly does not want to refer anyone at all but has got to this point in the form.

## Why? 

The additional family section covers family that the referrer may want to refer but that are not direct family members. As this is the last stage where a user can refer another person, if they do not want to add a person here and have not referred a person in previous sections then they are given a message (with no forward page) that they must refer at least one person.

## How?

Added a behaviour to add `over18` flag to locals where there may be no `req` object available to add the variable directly from config code.

## Testing?

Tested locally with conditional routing working ok

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
