### PR TITLE
ACRS-118: Fix bug that stops the BRP/UAN signed in with from appearing in the referrals list

### DIFF
--- a/apps/acrs/behaviours/resume-form-session.js
+++ b/apps/acrs/behaviours/resume-form-session.js
@@ -69,7 +69,7 @@ module.exports = superclass => class extends superclass {
         }
 
         const filteredCases = this.addCasesToSession(req, cases, idNumber);
-        this.setupRadioButtons(req, filteredCases.filter(form => form.id));
+        this.setupRadioButtons(req, filteredCases);
 
         return super.configure(req, res, next);
       })
@@ -129,7 +129,7 @@ module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     const cases = req.sessionModel.get('user-cases') || [];
     const idType = req.sessionModel.get('id-type');
-    const caseObj = cases.find(obj => obj.session[idType]);
+    const caseObj = cases.find(obj => obj.session[idType] === req.form.values.referral);
 
     if (caseObj) {
       req.sessionModel.set('id', caseObj.id);


### PR DESCRIPTION
## What? 

[ACRS-118](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-118)

Fixed a bug where the BRP/UAN option that was signed in with does not occur in the options of the radio list to choose the referral to continue with in the case of multiple referrals being found for the login email address.

Also updated code so that the correct array item is used when a selection is made from the subsequent radio list of possible referrals.

## Why? 

This bug forces a user to use a different referral they had already been filling instead of the one they presumably signed in to complete. It is interfering with testing and is a high priority fix.

## How? 

- Remove an extra filter for options with an ID (only referrals brought from the database contain one).
- When choosing which session to create and move forward with, ensure the array item with the same idType and id as the selected one is used

## Testing?

Tested locally. This will have to be tested in remote env.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
