### PR TITLE
ACRS-56/58: Add brother or sister question and details pages

### DIFF
--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -219,9 +219,7 @@ module.exports = {
     mixin: 'radio-group',
     options: ['yes', 'no'],
     validate: 'required',
-    legend: {
-      className: 'visuallyhidden'
-    }
+    isPageHeading: true
   },
   'additional-family': {
     legend: { className: 'bold' },

--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -221,6 +221,40 @@ module.exports = {
     validate: 'required',
     isPageHeading: true
   },
+  'brother-or-sister-full-name': {
+    validate: ['required', 'notUrl', { type: 'maxlength', arguments: [250] }],
+    labelClassName: 'bold'
+  },
+  'brother-or-sister-date-of-birth': dateComponent('brother-or-sister-date-of-birth', {
+    legend: { className: 'bold' },
+    validate: [
+      'required',
+      'before',
+      { type: 'after', arguments: ['2003-08-27'] }]
+  }),
+  'brother-or-sister-country': {
+    labelClassName: 'bold',
+    mixin: 'select',
+    validate: ['required', isInCountriesList],
+    className: ['js-hidden'],
+    options: [
+      {
+        value: '',
+        label: 'fields.brother-or-sister-country.options.null'
+      }
+    ].concat(_.sortBy(countries, o => o.label))
+  },
+  'brother-or-sister-evacuated-without-reason': {
+    labelClassName: 'bold',
+    mixin: 'textarea',
+    attributes: [{ attribute: 'rows', value: 5 }],
+    validate: [
+      'required',
+      'notUrl',
+      { type: 'regex', arguments: /^[^\[\]\|<>]*$/ },
+      { type: 'maxlength', arguments: 15000 }
+    ]
+  },
   'additional-family': {
     legend: { className: 'bold' },
     mixin: 'radio-group',

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -185,6 +185,7 @@ module.exports = {
     },
 
     '/brother-or-sister': {
+      behaviours: SaveFormSession,
       fields: ['brother-or-sister'],
       forks: [{
         target: '/additional-family',
@@ -193,7 +194,9 @@ module.exports = {
           value: 'no'
         }
       }],
-      next: '/brother-or-sister-details'
+      next: '/brother-or-sister-details',
+      locals: { showSaveAndExit: true },
+      continueOnEdit: true
     },
 
     '/brother-or-sister-details': {
@@ -218,7 +221,8 @@ module.exports = {
       }],
       behaviours: SaveFormSession,
       locals: { showSaveAndExit: true },
-      next: '/partner-details'
+      next: '/partner-details',
+      continueOnEdit: true
     },
 
     '/partner-details': {
@@ -293,7 +297,8 @@ module.exports = {
         }
       ],
       next: '/family-in-uk',
-      locals: { showSaveAndExit: true }
+      locals: { showSaveAndExit: true },
+      continueOnEdit: true
     },
 
     '/additional-family-details': {

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -200,8 +200,15 @@ module.exports = {
     },
 
     '/brother-or-sister-details': {
-      fields: [],
-      next: '/brother-or-sister-summary'
+      behaviours: SaveFormSession,
+      fields: [
+        'brother-or-sister-full-name',
+        'brother-or-sister-date-of-birth',
+        'brother-or-sister-country',
+        'brother-or-sister-evacuated-without-reason'
+      ],
+      next: '/brother-or-sister-summary',
+      locals: { showSaveAndExit: true }
     },
     '/brother-or-sister-summary': {
       fields: [],

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -220,6 +220,23 @@
       }
     }
   },
+  "brother-or-sister-full-name": {
+    "label": "Brother or sister's full name"
+  },
+  "brother-or-sister-date-of-birth": {
+    "legend": "Brother or sister's date of birth",
+    "hint": "For example, 27 3 1988. If they do not have a date of birth, enter a date that matches any evidence"
+  },
+  "brother-or-sister-country": {
+    "label": "What country do they live in?",
+    "hint": "Start to type the country and options will appear. Select 'Unknown' if you do not know",
+    "options": {
+      "null": "Select a country"
+    }
+  },
+  "brother-or-sister-evacuated-without-reason": {
+    "label": "Why were you evacuated without this brother or sister?"
+  },
   "additional-family": {
     "legend": "Are you referring additional family members to come to the UK?",
     "options": {

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -209,15 +209,16 @@
     "label": "Why were you evacuated without this parent?"
   },
   "brother-or-sister": {
-      "label": "SKELETON: brother-or-sister",
-      "options": {
-        "yes": {
-          "label": "SKELETON: Yes"
-        },
-        "no": {
-          "label": "SKELETON: No"
-        }
+    "legend": "Are you referring a brother or sister to come to the UK?",
+    "hint": "You can only refer brothers or sisters that your parents are responsible for",
+    "options": {
+      "yes": {
+        "label": "Yes"
+      },
+      "no": {
+        "label": "No"
       }
+    }
   },
   "additional-family": {
     "legend": "Are you referring additional family members to come to the UK?",

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -48,7 +48,8 @@
     "header": "SKELETON: /parent-summary"
   },
   "brother-or-sister-details": {
-    "header": "SKELETON: /brother-or-sister-details"
+    "header": "Brother or sister {{values.brotherOrSisterCount}} details",
+    "paragraph": "Add your brothers or sisters one at a time."
   },
   "brother-or-sister-summary": {
     "header": "SKELETON: /brother-or-sister-summary"

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -47,9 +47,6 @@
   "parent-summary": {
     "header": "SKELETON: /parent-summary"
   },
-  "brother-or-sister": {
-    "header": "SKELETON: /brother-or-sister"
-  },
   "brother-or-sister-details": {
     "header": "SKELETON: /brother-or-sister-details"
   },

--- a/apps/acrs/translations/src/en/validation.json
+++ b/apps/acrs/translations/src/en/validation.json
@@ -86,8 +86,8 @@
       "maxlength": "Telephone number must be between 8 and 16 characters",
       "internationalPhoneNumber": "Enter a telephone number, like 01632 960 001, 07700 900 982 or +44 808 157 0192"
     },
-      "brother-or-sister": {
-        "required": "You must select an option"
+    "brother-or-sister": {
+      "required": "You must select an option"
     },
     "partner": {
       "required": "You must select an option"

--- a/apps/acrs/translations/src/en/validation.json
+++ b/apps/acrs/translations/src/en/validation.json
@@ -89,6 +89,27 @@
     "brother-or-sister": {
       "required": "You must select an option"
     },
+    "brother-or-sister-full-name": {
+      "required": "Enter this brother or sister's full name",
+      "notUrl": "Please do not enter a link/url into your answers",
+      "maxlength": "Brother or sister's full name must be between 1 and 250 characters"
+    },
+    "brother-or-sister-date-of-birth": {
+      "required": "Enter brother or sister's date of birth",
+      "date": "Enter a real date of birth",
+      "after": "Brothers or sisters born before 28 August 2003 cannot be referred to come to the UK",
+      "before": "Brother or sister's date of birth must be in the past"
+    },
+    "brother-or-sister-country": {
+      "required": "Enter the country this brother or sister lives in",
+      "isInCountriesList": "You must choose a country from the provided list"
+    },
+    "brother-or-sister-evacuated-without-reason": {
+      "required": "Enter the reason you were evacuated without this brother or sister",
+      "maxlength": "Living situation details must be less than 15,000 characters",
+      "notUrl": "Please do not enter a link/url into your answers",
+      "regex": "Details must not include these characters: [ ] < > / |"
+    },
     "partner": {
       "required": "You must select an option"
     },

--- a/apps/acrs/views/brother-or-sister-details.html
+++ b/apps/acrs/views/brother-or-sister-details.html
@@ -1,0 +1,10 @@
+{{<partials-page}}
+  {{$page-content}}
+    <p>{{#t}}pages.brother-or-sister-details.paragraph{{/t}}</p>
+    <br>
+    {{#fields}}
+      {{#renderField}}{{/renderField}}
+    {{/fields}}
+    {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -204,3 +204,7 @@ pre.looped-records {
 .save-and-exit-button {
   margin-left: 15px;
 }
+
+.govuk-character-count__message {
+  display: none;
+}


### PR DESCRIPTION
## What? 

[ACRS-56](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-56)
[ACRS-58](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-58)

As the question page for "Are you referring a brother or sister to come to the UK?" and the subsequent details page for brothers and sisters if the answer was yes.

Adds step and field definitions, view, copy and validations.

## Why? 

The user can refer up to 100 brothers or sisters in their referral. These pages set up the design and basic routing to add brothers and sisters.

This update does not add the looping/aggregate behaviour. Additionally it does not add the 'brother or sister count' to track the number added to the form so far. This will also be added with the review page and aggregate behavior.

## Testing?

Tested validations and initial routing working ok locally.

## Screenshots (optional)

<img width="1659" alt="Screenshot 2024-06-01 at 17 52 58" src="https://github.com/UKHomeOffice/acrs/assets/137879919/d9abdac6-f5a3-47d7-8f65-4982c05851a4">

![localhost_8080_acrs_brother-or-sister-details](https://github.com/UKHomeOffice/acrs/assets/137879919/2bb36db4-0c94-42b2-b4bf-4be23b530cef)

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
