### PR TITLE
Replace confirm step that was moved up for testing pdf generation

### DIFF
--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -117,7 +117,7 @@ module.exports = {
           return ! Utilities.isOver18(req.sessionModel.get('date-of-birth'));
         }
       }],
-      next: '/confirm',
+      next: '/confirm-referrer-email',
       behaviours: SaveFormSession,
       locals: { showSaveAndExit: true }
     },


### PR DESCRIPTION
## What? 
Replace the next step for the full-name step from confirm to confirm-referrer-email
## Why? 
Confirm step that was moved up for testing pdf generation, this was corrected but has been over-risen by the latest merge
## How? 
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
