### PR TITLE
ACRS-66 Implement /partner-summary

### DIFF
--- a/apps/acrs/behaviours/limit-partners.js
+++ b/apps/acrs/behaviours/limit-partners.js
@@ -1,0 +1,21 @@
+/**
+ * Adds the LimitPartners behaviour to the steps.
+ * This provides a flag `noMorePartners` that indicates whether the user has
+ * reached the maximum number of partners that can be referred.
+ */
+
+module.exports = superclass => class extends superclass {
+  locals(req, res) {
+    const locals = super.locals(req, res);
+
+    const limit = req.form.options.aggregateLimit;
+    const aggregateTo = req.form.options.aggregateTo; // 'referred-partners'
+
+    const aggregate = req.sessionModel.get(aggregateTo);
+    if(aggregate && aggregate.aggregatedValues) {
+      locals.noMorePartners = aggregate.aggregatedValues.length >= limit;
+    }
+
+    return locals;
+  }
+};

--- a/apps/acrs/behaviours/partner-summary.js
+++ b/apps/acrs/behaviours/partner-summary.js
@@ -1,18 +1,18 @@
 const moment = require('moment');
 module.exports = superclass => class extends superclass {
   configure(req, res, next) {
-    const aggregateTo = req.form.options.aggregateTo; // 'referred-children'
+    const aggregateTo = req.form.options.aggregateTo; // 'referred-partners'
     const aggregate = req.sessionModel.get(aggregateTo);
 
-    // When all children are removed redirect to the loop section intro
+    // When all partners are removed redirect to the loop section intro
     if(aggregate && !aggregate.aggregatedValues.length) {
-      req.form.options.addStep = 'children';
+      req.form.options.addStep = 'partner';
     }
     super.configure(req, res, next);
   }
 
   /**
-   * Iterate the referred Children and fix up data in the fields
+   * Iterate the referred Partners and fix up data in the fields
    * Date of Birth is formatted to DD MMMM YYYY
    * By appending `.summary-heading` to the `.field` the legend used
    * in the summary is taken from "summary-heading" in fields.json
@@ -23,7 +23,6 @@ module.exports = superclass => class extends superclass {
    */
   locals(req, res) {
     const locals = super.locals(req, res);
-
     locals.items = locals.items.map(item => {
       item.fields = item.fields.map(field => {
         if (field.field.includes('date-of-birth')) {
@@ -36,7 +35,6 @@ module.exports = superclass => class extends superclass {
       });
       return item;
     });
-
     return locals;
   }
 };

--- a/apps/acrs/behaviours/summary-modify-change-link.js
+++ b/apps/acrs/behaviours/summary-modify-change-link.js
@@ -28,6 +28,9 @@ module.exports = superclass => class extends superclass {
                 if (field.field === 'family-member-fullname') {
                   field.changeLink = '/acrs/family-member-summary';
                 }
+                if (field.field === 'partner-full-name') {
+                  field.changeLink = '/acrs/partner-summary';
+                }
               });
             });
             return row;

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -21,12 +21,17 @@ const AdditionalFamilySummary = require('./behaviours/additional-family-summary'
 const LimitAdditionalFamily = require('./behaviours/limit-additional-family');
 const limitFamilyInUk = require('./behaviours/limit-family-in-uk');
 const familyInUkSummary = require('./behaviours/family-in-uk-summary');
+const PartnerSummary = require('./behaviours/partner-summary');
+const LimitPartners = require('./behaviours/limit-partners');
+
 
 // Aggregator section limits
 const PARENT_LIMIT = 2;
 const BROTHER_OR_SISTER_LIMIT = process.env.NODE_ENV === 'development' ? 5 : 100;
 const CHILDREN_LIMIT = process.env.NODE_ENV === 'development' ? 2 : 100;
 const ADDITIONAL_FAMILY_LIMIT = process.env.NODE_ENV === 'development' ? 5 : 100;
+const PARTNER_LIMIT = 1;
+
 
 module.exports = {
   name: 'acrs',
@@ -321,7 +326,6 @@ module.exports = {
       next: '/partner-details',
       continueOnEdit: true
     },
-
     '/partner-details': {
       fields: [
         'partner-full-name',
@@ -337,9 +341,36 @@ module.exports = {
       next: '/partner-summary'
     },
     '/partner-summary': {
-      fields: [],
+      behaviours: [
+        AggregateSaveUpdate,
+        PartnerSummary,
+        LimitPartners,
+        SaveFormSession
+      ],
+      aggregateTo: 'referred-partners',
+      aggregateFrom: [
+        'partner-full-name',
+        'partner-phone-number',
+        'partner-email',
+        'partner-date-of-birth',
+        'partner-country',
+        'partner-living-situation',
+        'partner-why-without-partner'
+      ],
+      aggregateLimit: PARTNER_LIMIT,
+      titleField: 'partner-full-name',
+      addStep: 'partner-details',
+      addAnotherLinkText: 'partner',
+      locals: {
+        showSaveAndExit: true,
+        referredPartnerLimit: PARTNER_LIMIT
+      },
+      continueOnEdit: false,
+      template: 'partner-summary',
+      backLink: 'partner',
       next: '/children'
     },
+
     '/children': {
       behaviours: [ResetSummary('referred-children', 'children'), SaveFormSession],
       fields: ['children'],

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -289,37 +289,5 @@ module.exports = {
         }
       }
     ]
-  },
-  'partner-details': {
-    steps: [
-      {
-        steps: '/partner-details',
-        field: 'partner-full-name'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-phone-number'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-email'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-date-of-birth'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-country'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-living-situation'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-why-without-partner'
-      }
-    ]
   }
 };

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -223,6 +223,39 @@ module.exports = {
         }
       },
       {
+        steps: '/partner',
+        field: 'partner',
+        parse: (list, req) => {
+          if ( !req.sessionModel.get('steps').includes('/partner') ) {
+            return null;
+          }
+          return req.sessionModel.get('partner') === 'yes' ? 'Yes' : 'No';
+        }
+      },
+      {
+        step: '/partner-summary',
+        field: 'referred-partners',
+        addElementSeparators: true,
+        dependsOn: 'partner',
+        parse: obj => {
+          if ( !obj?.aggregatedValues ) { return null; }
+
+          for (const item of obj.aggregatedValues) {
+            item.fields.map(field => {
+              field.isAggregatorTitle = field.field === 'partner-full-name';
+              field.omitChangeLink = true;
+              if (field.field.includes('date-of-birth')) {
+                if (field.value !== undefined) {
+                  field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+                }
+              }
+              return field;
+            });
+          }
+          return obj;
+        }
+      },
+      {
         step: '/children',
         field: 'children',
         parse: (list, req) => {

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -134,32 +134,39 @@
     "hint": "For international numbers, include the country code."
   },  
   "partner-full-name": {
-    "label": "Partner’s full name"
+    "label": "Partner’s full name",
+    "summary-heading": "Full name"
   },
   "partner-phone-number": {
     "label": "Partner’s telephone number (optional)",
-    "hint": "For international numbers include the country code"
+    "hint": "For international numbers include the country code",
+    "summary-heading": "Telephone number"
   },
   "partner-email": {
-    "label": "Partner’s email address (optional)"
+    "label": "Partner’s email address (optional)",
+    "summary-heading": "Email address"
   },
   "partner-date-of-birth": {
     "legend": "Partner’s date of birth",
-    "hint": "For example, 27 3 1988. If they do not have a date of birth, enter a date that matches any evidence"
+    "hint": "For example, 27 3 1988. If they do not have a date of birth, enter a date that matches any evidence",
+    "summary-heading": "Date of birth"
   },
   "partner-country": {
     "label": "What country do they live in?",
     "hint": "Start to type the country and options will appear. Select 'Unknown' if you do not know",
     "options": {
       "null": "Select a country"
-    }
+    },
+    "summary-heading": "Country they live in"
   },
   "partner-living-situation": {
     "label": "Partner’s living situation",
-    "hint": "For example, who they are living with, their relationship to who they are living with and how long they have lived there"
+    "hint": "For example, who they are living with, their relationship to who they are living with and how long they have lived there",
+    "summary-heading": "Living situation"
   },
   "partner-why-without-partner": {
-    "label": "Why were you evacuated without your partner?"
+    "label": "Why were you evacuated without your partner?",
+    "summary-heading": "Why you were evacuated without them"
   },
   "children": {
     "legend": "Are you referring your children to come to the UK?",

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -69,7 +69,9 @@
     "header": "Partner's details"
   },
   "partner-summary": {
-    "header": "SKELETON: /partner-summary"
+    "header": "Partner you are referring",
+    "partner-limit-message": "You can only refer one partner to come to the UK.",
+    "partner-limit-exceeded": "You can not refer any more partners."
   },
   "children": {
     "header": "Children aged under 18",

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -255,6 +255,27 @@
       },
       "additional-family-why-referring": {
         "label": "Why are you referring them?"
+      },
+      "partner-full-name": {
+        "label": "Partner's name"
+      },
+      "partner-phone-number": {
+        "label": "Telephone number"
+      },
+      "partner-email": {
+        "label": "Email address"
+      },
+      "partner-date-of-birth": {
+        "label": "Date of birth"
+      },
+      "partner-country": {
+        "label": "Country"
+      },
+      "partner-living-situation": {
+        "label": "Partner’s living situation"
+      },
+      "partner-why-without-partner": {
+        "label": "Not evacuated together because"
       }
     }
   }

--- a/apps/acrs/views/partner-summary.html
+++ b/apps/acrs/views/partner-summary.html
@@ -1,0 +1,10 @@
+{{<partials-page}}
+  {{$page-content}}
+  
+  {{> partials-aggregator-summary-table}}
+
+  <p class="govuk-body">{{#t}}pages.partner-summary.partner-limit-message{{/t}}</p>
+  <br>
+  {{#input-submit}}continue{{/input-submit}}
+  {{/page-content}}
+{{/partials-page}}

--- a/apps/acrs/views/partner-summary.html
+++ b/apps/acrs/views/partner-summary.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
-  
+
   {{> partials-aggregator-summary-table}}
 
   <p class="govuk-body">{{#t}}pages.partner-summary.partner-limit-message{{/t}}</p>


### PR DESCRIPTION
## What? 

[ACRS-66 18+ UK ROUTE - Create a 'Partner you are referring' summary page](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-66)
Adds the /partner-summary page with looping aggregator limit of 1.

The partner details have been included into the final summary page `/confirm` though it is not currently up to spec and will need to be revisited.

## Why? 

The aggregation or "many" pattern has been used to capture partner details even though the referral is restricted to a single partner to take advantage of the framework's summary behaviour.


## Check list

Checked
