### PR TITLE
ACRS-144 Remove the phase banner from ACRS form

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,7 +22,6 @@ app.use((req, res, next) => {
   const protocol = host.includes('localhost') ? 'http' : 'https';
   res.locals.formUrl = `${protocol}://${host}`;
   res.locals.htmlLang = 'en';
-  res.locals.feedbackUrl = '/https://eforms.homeoffice.gov.uk/outreach/feedback.ofml';
   next();
 });
 

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -102,7 +102,7 @@ describe('Server.js app file', () => {
 
   describe('Use Locals', () => {
     it('should set locals on the response', () => {
-      expect(res.locals).to.have.all.keys('formUrl', 'htmlLang')
+      expect(res.locals).to.have.all.keys('formUrl', 'htmlLang');
     });
 
     it('should call next twice', () => {

--- a/test/_unit/server.spec.js
+++ b/test/_unit/server.spec.js
@@ -102,11 +102,7 @@ describe('Server.js app file', () => {
 
   describe('Use Locals', () => {
     it('should set locals on the response', () => {
-      res.locals.should.eql({
-        formUrl: 'http://localhost',
-        htmlLang: 'en',
-        feedbackUrl: '/https://eforms.homeoffice.gov.uk/outreach/feedback.ofml'
-      });
+      expect(res.locals).to.have.all.keys('formUrl', 'htmlLang')
     });
 
     it('should call next twice', () => {


### PR DESCRIPTION
## What? 

[ACRS-144](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-144) 
Remove the phase banner from the ACRS form

## Why? 

The phase banner contains the feedback link to a form where users can typically give feedback on the service.

The business team are concerned that users will attempt to use the feedback link and form to provide more sensitive referral context through this channel. As such they have asked for us to remove the link.

## How?

Removing the link from the settings in server.js (providing HOF with no link) disables the whole banner in the layout.html view in the HOF framework.
 
## Testing?

Tested locally and banner is removed.

## Screenshots (optional)

Before:
<img width="1319" alt="Screenshot 2024-06-11 at 16 13 35" src="https://github.com/UKHomeOffice/acrs/assets/137879919/fc1a88dd-bc0d-42b2-851a-cfc4c765acf4">

After:
<img width="1376" alt="Screenshot 2024-06-11 at 16 10 18" src="https://github.com/UKHomeOffice/acrs/assets/137879919/73401962-5692-4377-aa6a-e595f860b550">

## Anything Else? (optional)

Leaving the banner intact but removing the feedback form link only would be much more complex as this part of the code is in the HOF framework. You could possibly provide a generic link to a non-form location, but this would be misleading to users.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
