### PR TITLE
ACRS-139 Fix page title indexing in additional-family-details and family-in-uk-details pages

### DIFF
--- a/apps/acrs/behaviours/limit-additional-family.js
+++ b/apps/acrs/behaviours/limit-additional-family.js
@@ -10,7 +10,7 @@ module.exports = superclass => class extends superclass {
       if (referredAdditionalFamily && additionalFamilyLimit) {
         locals.noMoreAdditionalFamily = true;
       }
-      locals.referredAdditionalFamilyCount = referredAdditionalFamilyCount.toString();
+      locals.additionalFamilyCount = referredAdditionalFamilyCount.toString();
     }
     if (req.sessionModel.get('aggregator-edit-id')) {
       locals.additionalFamilyCount = parseInt(req.sessionModel.get('aggregator-edit-id'), 10) + 1;

--- a/apps/acrs/behaviours/limit-family-in-uk.js
+++ b/apps/acrs/behaviours/limit-family-in-uk.js
@@ -8,13 +8,14 @@ module.exports = superclass => class extends superclass {
       const familyMemberCount = familyMembers.length + 1;
 
       if (familyMembers && familyMemberLimit) {
-        locals.noMoreParents = true;
+        locals.noMoreFamilyMembers = true;
       }
-
-
       locals.familyMemberCount = familyMemberCount.toString();
     }
-
+    if (req.sessionModel.get('aggregator-edit-id')) {
+      locals.familyMemberCount = parseInt(req.sessionModel.get('aggregator-edit-id'), 10) + 1;
+      req.sessionModel.unset('aggregator-edit-id');
+    }
     return locals;
   }
 };

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -545,7 +545,7 @@ module.exports = {
       behaviours: Locals18Flag
     },
     '/family-in-uk': {
-      behaviours: [SaveFormSession],
+      behaviours: [ResetSummary('family-member-in-uk', 'family-in-uk'), SaveFormSession],
       forks: [
         {
           target: '/family-in-uk-details',

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -290,38 +290,6 @@ module.exports = {
       }
     ]
   },
-  'partner-details': {
-    steps: [
-      {
-        steps: '/partner-details',
-        field: 'partner-full-name'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-phone-number'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-email'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-date-of-birth'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-country'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-living-situation'
-      },
-      {
-        steps: '/partner-details',
-        field: 'partner-why-without-partner'
-      }
-    ]
-  },
   'evidence-documents': [
     {
       step: '/upload-evidence',

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -41,16 +41,12 @@
     "paragraph": "If you have no fixed address, enter an address we can use to contact you."
   },
   "parent-details": {
-    "header": "Parent {{values.parentCount}} details",
     "paragraph": "Add your parents one at a time."
   },
   "parent-summary": {
     "header": "Parents you are referring",
     "parent-limit-message": "You can refer a maximum of 2 parents to come to the UK.",
     "parent-limit-exceeded": "You can not refer any more parents."
-  },
-  "brother-or-sister": {
-    "header": "SKELETON: /brother-or-sister"
   },
   "brother-or-sister-details": {
     "paragraph": "Add your brothers or sisters one at a time."
@@ -150,9 +146,6 @@
     "header": "Postal address for the decision",
     "hint": "If you have no fixed address, enter an address we can use to contact you",
     "title": "Postal address for the decision - Refer family to come to the UK"
-  },
-  "your-postal-address": {
-    "header": "SKELETON: /your-postal-address"
   },
   "declaration": {
     "header": "SKELETON: /declaration"

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -125,7 +125,7 @@
   },
   "family-in-uk-summary": {
     "header": "Family members that live in the UK",
-    "family-in-uk-limit-exceeded": "You can not refer any more family members in the UK."
+    "family-in-uk-limit-exceeded": "You can not add any more family members in the UK."
   },
   "upload-evidence": {
     "header": "Upload evidence"

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -128,7 +128,8 @@
     "hint": "Enter the details of a family member that lives in the UK."
   },
   "family-in-uk-summary": {
-    "header": "Family members that live in the UK"
+    "header": "Family members that live in the UK",
+    "family-in-uk-limit-exceeded": "You can not refer any more family members in the UK."
   },
   "upload-evidence": {
     "header": "Upload evidence"

--- a/apps/acrs/views/family-in-uk-summary.html
+++ b/apps/acrs/views/family-in-uk-summary.html
@@ -1,11 +1,17 @@
 {{<partials-page}}
   {{$page-content}}
     <title>{{#t}}pages.uk-family-member-details.header{{/t}} – GOV.UK</title>
-  
-    <!-- {{> partials-family-in-uk-summary-table}} -->
     {{> partials-aggregator-summary-table}}
-    <p><a class="add-another-button govuk-button govuk-button--secondary" href="{{baseUrl}}/{{addStep}}">Add another {{addAnotherLinkText}}</a></p>
-    
+    {{#noMoreFamilyMembers}}
+      <p>{{#t}}pages.family-in-uk-summary.family-in-uk-limit-exceeded{{/t}}</p>
+    {{/noMoreFamilyMembers}}
+    <br>
+    {{^noMoreFamilyMembers}}
+    <a href="{{baseUrl}}/{{addStep}}" class="add-another-button govuk-button govuk-button--secondary" data-module="govuk-button">
+      Add another {{addAnotherLinkText}}
+    </a>
+    <br>
+    {{/noMoreFamilyMembers}}
     {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}

--- a/apps/acrs/views/family-in-uk-summary.html
+++ b/apps/acrs/views/family-in-uk-summary.html
@@ -7,7 +7,7 @@
     {{/noMoreFamilyMembers}}
     <br>
     {{^noMoreFamilyMembers}}
-    <a href="{{baseUrl}}/{{addStep}}" class="add-another-button govuk-button govuk-button--secondary" data-module="govuk-button">
+    <a href="{{baseUrl}}/{{addStep}}" class="govuk-button govuk-button--secondary" data-module="govuk-button">
       Add another {{addAnotherLinkText}}
     </a>
     <br>


### PR DESCRIPTION
## What?

[ACRS-139](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-139)
Fix additional family index not displaying properly when adding new additional family
Fix family in UK index not displaying properly when editing existing family members

Allowed family in UK aggregator to be cleared when 'no' is selected after initially selecting yes in the section intro.
Removed some old code that was reintroduced by accident in #75
 
## Why? 

Index number in the page title for the number of family member being updated/added under different situations was not being displayed properly. For additional family this was in add cases, for family in the Uk this was in editing an existing member.

## How?

Fixed a bad assignment of the local value for additional family members
Added missing logic that was present in other aggregates for family in the UK

## Testing?

Tested locally and aggregates appear to operate as expected.

## Anything Else? (optional)

If this fails in testing it is likely we will remove the index from the <aggregate>-details page headings.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
