### PR TITLE
ACRS-114 Change the question wording on /confirm-your-email

### DIFF
--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -31,7 +31,7 @@ module.exports = {
     mixin: 'input-text',
     validate: ['required', { type: 'maxlength', arguments: 250 }]
   },
-  'confirm-referrer-email': {
+  'confirm-your-email': {
     mixin: 'radio-group',
     options: ['yes', 'no'],
     validate: 'required',

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -127,16 +127,16 @@ module.exports = {
           return ! Utilities.isOver18(req.sessionModel.get('date-of-birth'));
         }
       }],
-      next: '/confirm-referrer-email',
+      next: '/confirm-your-email',
       behaviours: SaveFormSession,
       locals: { showSaveAndExit: true }
     },
-    '/confirm-referrer-email': {
-      fields: ['confirm-referrer-email'],
+    '/confirm-your-email': {
+      fields: ['confirm-your-email'],
       forks: [{
         target: '/your-email',
         condition: {
-          field: 'confirm-referrer-email',
+          field: 'confirm-your-email',
           value: 'no'
         }
       }],

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -27,13 +27,13 @@ module.exports = {
         field: 'full-name'
       },
       {
-        steps: '/confirm-referrer-email',
-        field: 'confirm-referrer-email',
+        steps: '/confirm-your-email',
+        field: 'confirm-your-email',
         parse: (list, req) => {
-          if (!req.sessionModel.get('steps').includes('/confirm-referrer-email')) {
+          if (!req.sessionModel.get('steps').includes('/confirm-your-email')) {
             return null;
           }
-          return req.sessionModel.get('confirm-referrer-email') === 'yes' ?
+          return req.sessionModel.get('confirm-your-email') === 'yes' ?
             `${req.sessionModel.get('user-email')}` :
             `${req.sessionModel.get('referral-email')}`;
         }

--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -74,7 +74,7 @@
     "label": "What is your full name?",
     "hint": "You can copy this from your biometric residence permit card or any letters from the Home Office"
   },
-  "confirm-referrer-email": {
+  "confirm-your-email": {
     "options": {
         "yes": {
           "label": "Yes"

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -24,7 +24,7 @@
     "header": "Complete this form as if you are the referrer",
     "paragraph": "Answer all remaining questions as if you are the person referring family to come the UK."
   },
-  "confirm-referrer-email": {
+  "confirm-your-email": {
     "header": "Is this {{values.full-name}}’s email address?",
     "paragraph": "We may use this email address to contact them for more information about the referral."
   },
@@ -202,7 +202,7 @@
       "full-name": {
         "label": "Full name"
       },
-      "confirm-referrer-email": {
+      "confirm-your-email": {
         "label": "Email"
       },
       "legal-representative-fullname": {

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -25,8 +25,8 @@
     "paragraph": "Answer all remaining questions as if you are the person referring family to come the UK."
   },
   "confirm-your-email": {
-    "header": "Is this {{values.full-name}}’s email address?",
-    "paragraph": "We may use this email address to contact them for more information about the referral."
+    "header": "Is this your email address?",
+    "paragraph": "We may use this email address to contact you for more information about the referral."
   },
   "your-email": {
     "header": "Do you have an email address?",

--- a/apps/acrs/translations/src/en/validation.json
+++ b/apps/acrs/translations/src/en/validation.json
@@ -20,7 +20,7 @@
       "required": "You must enter your full name",
       "maxlength": "You can't use more than {{maxlength}} characters for your answer"
     },
-    "confirm-referrer-email": {
+    "confirm-your-email": {
       "required": "You must select an option"
     },
     "your-email-options": {

--- a/apps/acrs/views/confirm-your-email.html
+++ b/apps/acrs/views/confirm-your-email.html
@@ -1,8 +1,8 @@
 {{<partials-page}}
   {{$page-content}}
     <p class="bold">{{#t}}{{values.user-email}}{{/t}}</p>
-    <p class="govuk-hint">{{#t}}pages.confirm-referrer-email.paragraph{{/t}}</p>
-    {{#radio-group}}confirm-referrer-email{{/radio-group}}
+    <p class="govuk-hint">{{#t}}pages.confirm-your-email.paragraph{{/t}}</p>
+    {{#radio-group}}confirm-your-email{{/radio-group}}
     {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}

--- a/apps/acrs/views/your-email.html
+++ b/apps/acrs/views/your-email.html
@@ -1,6 +1,6 @@
 {{<partials-page}}
   {{$page-content}}
-    <p>{{#t}}pages.your-email.paragraph{{/t}}</p>
+    <p class="govuk-hint">{{#t}}pages.your-email.paragraph{{/t}}</p>
     <br>
     {{#fields}}
       {{#renderField}}{{/renderField}}


### PR DESCRIPTION
## What? 

[ACRS-114 Change the question wording on /confirm-your-email](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-114)

The path to this page is updated to `/confirm-your-email` (from '/confirm-referrer-email') so all internal references have also been updated.
