### PR TITLE
ACRS-124 Allow lowercase sign in for BRP users

### DIFF
--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -8,7 +8,7 @@ const baseUrl = `${config.saveService.host}:${config.saveService.port}/verify_lo
 module.exports = superclass => class extends superclass {
   async saveValues(req, res, next) {
     const queryColumn = req.sessionModel.get('sign-in-method') ?? null;
-    const queryValue = req.form.values[queryColumn].toUpperCase() ?? null;
+    const queryValue = req.form.values[queryColumn]?.toUpperCase() ?? null;
     req.form.values[queryColumn] = queryValue;
     if (!queryColumn || !queryValue) {
       return res.redirect('/incorrect-details-brp');

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -40,7 +40,7 @@ module.exports = superclass => class extends superclass {
         return res.redirect(`/incorrect-details-${queryColumn}`);
       }
     } catch (error) {
-      return next(error)
+      return next(Error(`Failed to verify referrer login details: ${error}`));
     }
     return super.saveValues(req, res, next);
   }

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -7,18 +7,12 @@ const baseUrl = `${config.saveService.host}:${config.saveService.port}/verify_lo
 
 module.exports = superclass => class extends superclass {
   async saveValues(req, res, next) {
-    let queryColumn;
-    switch(true) {
-      case !!req.form.values.brp:
-        queryColumn = 'brp';
-        break;
-      case !!req.form.values.uan:
-        queryColumn = 'uan';
-        break;
-      default:
-        return res.redirect('/incorrect-details-brp');
+    const queryColumn = req.sessionModel.get('sign-in-method') ?? null;
+    const queryValue = req.form.values[queryColumn].toUpperCase() ?? null;
+    req.form.values[queryColumn] = queryValue;
+    if (!queryColumn || !queryValue) {
+      return res.redirect('/incorrect-details-brp');
     }
-    const queryValue = req.form.values[queryColumn];
 
     const validCase = await this.isValidCase(req, queryColumn, queryValue);
     if (!validCase) {

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -5,6 +5,26 @@ const logger = require('hof/lib/logger')({ env: config.env });
 
 const baseUrl = `${config.saveService.host}:${config.saveService.port}/verify_lookup`;
 
+const isValidCase = async (req, queryColumn, queryValue) => {
+  const dob = req.form.values['date-of-birth'];
+
+  try {
+    const response = await axios.get(`${baseUrl}/${queryColumn}/${queryValue}`);
+    const validCases = response.data;
+
+    const foundCase = validCases.find(record => {
+      return record[queryColumn] === req.form.values[queryColumn] && record['date_of_birth'] === dob;
+    });
+
+    req.sessionModel.set('service', 'acrs');
+
+    return foundCase;
+  } catch (error) {
+    logger.log('error', `Could not get valid cases: ${error}`);
+    throw error;
+  }
+}
+
 module.exports = superclass => class extends superclass {
   async saveValues(req, res, next) {
     const queryColumn = req.sessionModel.get('sign-in-method') ?? null;
@@ -14,30 +34,14 @@ module.exports = superclass => class extends superclass {
       return res.redirect('/incorrect-details-brp');
     }
 
-    const validCase = await this.isValidCase(req, queryColumn, queryValue);
-    if (!validCase) {
-      return res.redirect(`/incorrect-details-${queryColumn}`);
+    try {
+      const validCase = await isValidCase(req, queryColumn, queryValue);
+      if (!validCase) {
+        return res.redirect(`/incorrect-details-${queryColumn}`);
+      }
+    } catch (error) {
+      return next(error)
     }
     return super.saveValues(req, res, next);
-  }
-
-  async isValidCase(req, queryColumn, queryValue) {
-    const dob = req.form.values['date-of-birth'];
-
-    try {
-      const response = await axios.get(`${baseUrl}/${queryColumn}/${queryValue}`);
-      const validCases = response.data;
-
-      const foundCase = validCases.find(record => {
-        return record[queryColumn] === req.form.values[queryColumn] && record['date_of_birth'] === dob;
-      });
-
-      req.sessionModel.set('service', 'acrs');
-
-      return foundCase;
-    } catch (error) {
-      logger.log('error', `Could not get valid cases: ${error}`);
-      return null;
-    }
   }
 };

--- a/apps/verify/behaviours/validate-case-details.js
+++ b/apps/verify/behaviours/validate-case-details.js
@@ -23,7 +23,7 @@ const isValidCase = async (req, queryColumn, queryValue) => {
     logger.log('error', `Could not get valid cases: ${error}`);
     throw error;
   }
-}
+};
 
 module.exports = superclass => class extends superclass {
   async saveValues(req, res, next) {


### PR DESCRIPTION
## What? 

[ACRS-124](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-124)
Users of BRP signin (Format roughly RZ0000000 or RZX000000) may attempt to sign in with their brp in lowercase - for the letter portion at least.

Ensured HOF form validation on the `/sign-in-brp` page and subsequent comparison with database values in verification allows for this use-case.

## Why? 

Users may want to sign in with a BRP number in lowercase. The business team have asked us to attempt to allow this use-case.

## How? 

Forcing the entered BRP (or UAN though in all digits this doesn't matter) into uppercase before comparison with the database values in the verify_lookup table (confirmed to be uppercase uniformly) allows us to have more lenient validation on the frontend (already existed) while still making sure the comparison with DB values will be successful.

## Testing?

Tested updates locally with UAN and BRP values

## Anything Else? (optional)

The business have confirmed that all BRP values in the database will be uppercase.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
