### PR TITLE
ACRS-128 Show save and exit button on 'Can you provide a telephone number?' screen

### DIFF
--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -159,6 +159,8 @@ module.exports = {
         'provide-telephone-number-options',
         'provide-telephone-number-number'
       ],
+      behaviours: SaveFormSession,
+      locals: { showSaveAndExit: true },
       next: '/your-address'
     },
     '/your-address': {


### PR DESCRIPTION
## What? 

[ACRS-128](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-128)
Add Save and exit button and behaviour to the form screen 'Can you provide a telephone number?'

## Why? 

This page should have the `SaveFormSession` behaviour and 'Save and exit' button so the user can exit the form at this point with session saved to database

## How? 

Added necessary fields to `acrs/index.js`

## Screenshots (optional)

Local page running after update:
<img width="1339" alt="Screenshot 2024-06-13 at 16 48 50" src="https://github.com/UKHomeOffice/acrs/assets/137879919/696327bd-735a-4c3e-b5fe-f41531ca3462">

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
