### PR TITLE
ACRS-147: Add missing legend for partner so it shows on summary pages

### DIFF
--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -110,6 +110,7 @@
     "label": "Postcode"
   },
   "partner": {
+    "legend": "Are you referring a partner to come to the UK?",
     "options": {
         "yes": {
           "label": "Yes"


### PR DESCRIPTION
## What? 

[ACRS-147](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-147)
Add a missing legend to fields.json so that it appears in the summary page.

## Why? 

Field label in summary was showing js object link but not proper copy.

## Screengrabs

<img width="1056" alt="Screenshot 2024-06-14 at 11 22 27" src="https://github.com/UKHomeOffice/acrs/assets/137879919/9e920a23-85fe-4207-b999-2effb15a2caa">
<img width="1181" alt="Screenshot 2024-06-14 at 11 22 18" src="https://github.com/UKHomeOffice/acrs/assets/137879919/31fa9dde-d05c-4213-bcce-0e6b2f5a8755">

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
