### PR TITLE
ACRS-17: Allow 'sign-in-method' to be brought from verify to acrs app session

### DIFF
--- a/apps/acrs/behaviours/check-email-token.js
+++ b/apps/acrs/behaviours/check-email-token.js
@@ -20,6 +20,7 @@ module.exports = superclass => class extends superclass {
       req.sessionModel.set('brp', brpId);
       req.sessionModel.set('uan', uanId);
       req.sessionModel.set('id-type', getIdType(brpId));
+      req.sessionModel.set('sign-in-method', _.get(req.session['hof-wizard-verify'], 'sign-in-method'))
       req.sessionModel.set('date-of-birth', _.get(req.session['hof-wizard-verify'], 'date-of-birth'));
 
       return super.saveValues(req, res, next);
@@ -39,6 +40,7 @@ module.exports = superclass => class extends superclass {
           req.sessionModel.set('uan', user.uan);
           req.sessionModel.set('brp', user.brp);
           req.sessionModel.set('id-type', getIdType(user.brp));
+          req.sessionModel.set('sign-in-method', user['sign-in-method']);
           req.sessionModel.set('date-of-birth', user['date-of-birth']);
           return super.saveValues(req, res, next);
         }

--- a/apps/acrs/behaviours/check-email-token.js
+++ b/apps/acrs/behaviours/check-email-token.js
@@ -20,7 +20,7 @@ module.exports = superclass => class extends superclass {
       req.sessionModel.set('brp', brpId);
       req.sessionModel.set('uan', uanId);
       req.sessionModel.set('id-type', getIdType(brpId));
-      req.sessionModel.set('sign-in-method', _.get(req.session['hof-wizard-verify'], 'sign-in-method'))
+      req.sessionModel.set('sign-in-method', _.get(req.session['hof-wizard-verify'], 'sign-in-method'));
       req.sessionModel.set('date-of-birth', _.get(req.session['hof-wizard-verify'], 'date-of-birth'));
 
       return super.saveValues(req, res, next);

--- a/config.js
+++ b/config.js
@@ -64,7 +64,17 @@ module.exports = {
   },
   sessionDefaults: {
     steps: ['/start', '/select-form', '/information-you-have-given-us', '/who-completing-form'],
-    fields: ['user-email', 'id-type', 'brp', 'uan', 'date-of-birth', 'csrf-secret', 'errorValues', 'errors']
+    fields: [
+      'user-email',
+      'id-type',
+      'sign-in-method',
+      'brp',
+      'uan',
+      'date-of-birth',
+      'csrf-secret',
+      'errorValues',
+      'errors'
+    ]
   },
   hosts: {
     acceptanceTests: process.env.ACCEPTANCE_HOST_NAME || `http://localhost:${process.env.PORT || 8080}`

--- a/db/get-token.js
+++ b/db/get-token.js
@@ -13,6 +13,7 @@ const read = async token => {
   user.email = await redis.get(`${token}:email`);
   user.brp = await redis.get(`${token}:brp`);
   user.uan = await redis.get(`${token}:uan`);
+  user['sign-in-method'] = await redis.get(`${token}:sign-in-method`)
   user['date-of-birth'] = await redis.get(`${token}:date-of-birth`);
 
   return user;

--- a/db/get-token.js
+++ b/db/get-token.js
@@ -13,7 +13,7 @@ const read = async token => {
   user.email = await redis.get(`${token}:email`);
   user.brp = await redis.get(`${token}:brp`);
   user.uan = await redis.get(`${token}:uan`);
-  user['sign-in-method'] = await redis.get(`${token}:sign-in-method`)
+  user['sign-in-method'] = await redis.get(`${token}:sign-in-method`);
   user['date-of-birth'] = await redis.get(`${token}:date-of-birth`);
 
   return user;

--- a/db/save-token.js
+++ b/db/save-token.js
@@ -11,6 +11,7 @@ module.exports = {
     redis.set(`${token}:email`, email);
     redis.set(`${token}:brp`, req.sessionModel.get('brp'));
     redis.set(`${token}:uan`, req.sessionModel.get('uan'));
+    redis.set(`${token}:sign-in-method`, req.sessionModel.get('sign-in-method'));
     redis.set(`${token}:date-of-birth`, req.sessionModel.get('date-of-birth'));
     redis.expire(`token:${token}`, tokenExpiry);
     redis.expire(`${token}:email`, tokenExpiry);


### PR DESCRIPTION
## What? 

[ACRS-17](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-17)
Allow the value for 'sign-in-method' to move from the verify session into the acrs session, so that the value will appear in the daily report CSV.

## Why? 

Although the field exists in the CSV, the values are missing as they are not present in the ACRS session which is used to populate. This information is required in the CSV.

## How?

Add the value from the verify session to the token stored while the user verifies by email. Add `'sign-in-method'` to values that are not removed from the new session when it is cleaned.
 
## Testing?

Tested locally the value appears in CSV

## Anything Else? (optional)

Now that this value is in the ACRS session it could actually be used as the session 'id-type' value. However as the current implementation is working it seems unwise to make this larger change at this time.


## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
