### PR TITLE
ACRS-166: De-index ACRS form

### DIFF
--- a/apps/acrs/views/partials/head.html
+++ b/apps/acrs/views/partials/head.html
@@ -1,0 +1,26 @@
+{{#gtmTagId}}
+{{#cookiesAccepted}}
+<!-- Google Tag Manager Data Layer  -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  var dataLayer = window.dataLayer || [];
+  dataLayer.push(
+    {{{gtmConfig}}}
+  );
+</script>
+<!-- End Google Tag Manager Data Layer  -->
+
+<!-- Google Tag Manager -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{gtmTagId}}');
+</script>
+<!-- End Google Tag Manager -->
+{{/cookiesAccepted}}
+{{/gtmTagId}}
+
+<meta name="robots" content="noindex">
+<meta name="format-detection" content="telephone=no">
+<link rel="stylesheet" href="{{assetPath}}/css/app.css">

--- a/apps/verify/views/partials/head.html
+++ b/apps/verify/views/partials/head.html
@@ -1,0 +1,26 @@
+{{#gtmTagId}}
+{{#cookiesAccepted}}
+<!-- Google Tag Manager Data Layer  -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  var dataLayer = window.dataLayer || [];
+  dataLayer.push(
+    {{{gtmConfig}}}
+  );
+</script>
+<!-- End Google Tag Manager Data Layer  -->
+
+<!-- Google Tag Manager -->
+<script {{#nonce}}nonce="{{nonce}}"{{/nonce}}>
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','{{gtmTagId}}');
+</script>
+<!-- End Google Tag Manager -->
+{{/cookiesAccepted}}
+{{/gtmTagId}}
+
+<meta name="robots" content="noindex">
+<meta name="format-detection" content="telephone=no">
+<link rel="stylesheet" href="{{assetPath}}/css/app.css">


### PR DESCRIPTION
## What? 
De-index the ACRS form - [ACRS-166](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-166)

## Why? 
So that the form is not returned via browser searches

## How? 
Add the following HTML files to override the default head.html in the framework, including the `<meta>` robots tag with the "noindex" content value:
- `acrs/views/partials/head.html`
- `verify/views/partials/head.html`

## Testing?
Tested locally and in branch

## Screenshots (optional)
#### Sign-in page (branch):
<img width="1432" alt="image" src="https://github.com/UKHomeOffice/acrs/assets/142597294/aaad6ac8-3d18-452f-999b-66e3a8218caf">

#### Main flow (branch):
<img width="1432" alt="image" src="https://github.com/UKHomeOffice/acrs/assets/142597294/77aabae0-c81f-4292-b388-2d332390a05c">

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
