### PR TITLE
ACRS-175 Only send customer receipt email to the address used during verification

### DIFF
--- a/apps/acrs/behaviours/create-and-send-pdf.js
+++ b/apps/acrs/behaviours/create-and-send-pdf.js
@@ -97,16 +97,12 @@ module.exports = class CreateAndSendPDF {
     if (!this.behaviourConfig.sendReceipt) {
       return Promise.resolve();
     }
-    const allUniqueEmails = req.sessionModel.get('all-unique-emails');
+    const userEmail = req.sessionModel.get('user-email');
 
     try {
-      const sendAllEmails = allUniqueEmails.map(email => this.sendEmail(req, email, pdfData));
-
-      return Promise.all(sendAllEmails)
-        .then(() => req.log('info', 'acrs.send_receipt.create_email_notify.successful'))
-        .catch(e => {
-          throw e;
-        });
+      const receiptResponse = await this.sendEmail(req, userEmail, pdfData);
+      req.log('info', 'acrs.send_receipt.create_email_notify.successful');
+      return receiptResponse;
     } catch (err) {
       req.log('error', 'acrs.send_receipt.create_email_notify.error', err.message || err);
       throw err;

--- a/apps/acrs/behaviours/submit.js
+++ b/apps/acrs/behaviours/submit.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const CreateAndSendPDF = require('./create-and-send-pdf');
 
 module.exports = superclass => class extends superclass {
@@ -11,29 +10,6 @@ module.exports = superclass => class extends superclass {
     });
     // don't await async process, allow user to move on
     uploadPdfShared.send(req, res, super.locals(req, res));
-
-    const userEmail = req.sessionModel.get('user-email');
-
-    // use either the email entered on the validation page or the one entered within the form
-    let userFormEmail = '';
-    if(req.sessionModel.get('current-email') === 'yes') {
-      userFormEmail = userEmail;
-    } else if(req.sessionModel.get('current-email') === 'no') {
-      userFormEmail = req.sessionModel.get('email-address-details');
-    }
-
-    let advisorEmail = '';
-    if(req.sessionModel.get('is-legal-representative-email') === 'yes') {
-      advisorEmail = userEmail;
-    } else if(req.sessionModel.get('is-legal-representative-email') === 'no') {
-      advisorEmail = req.sessionModel.get('legal-representative-email');
-    }
-
-    const claimsEmail = process.env.CLAIMS_EMAIL;
-
-    const allUniqueEmails = _.uniq([userEmail, userFormEmail, advisorEmail, claimsEmail].filter(e => e));
-
-    req.sessionModel.set('all-unique-emails', allUniqueEmails);
 
     return super.successHandler(req, res, next);
   }


### PR DESCRIPTION
## What? 

Stop the submit behaviour trying to send a 'referrer' receipt email to several different email addresses.
Remove the code from older project that gathers a series of email addresses to send the receipt to. Send only to the `'user-email'` as used to verify with the form in the first place.

## Why? 

For ACRS we only want to send two emails on submit - a referrer receipt and a caseworker receipt. We had an issue where adding an 'immigration advisor' email to a form submission would send a third email in ACRS. 

This code was copied from another project (IMA) where the equivalent of a referrer receipt is sent to a series of addresses if they were added in the form. The caseworker receipt is sent separately as part of the process.

## How? 

- Removed the chunk of code in submit behaviour that gathers then stores unique supplied emails from across the form session as an array in session - we won't need this because we only send to one email now.
- Removed retrieving the above array and then using `Promise.all` to sends to each address in the array. Now we retrieve only the one email address we want from session and await sending directly there.
- Kept logging present as it was before.

## Testing?

Tested locally, will need a few runs in UAT and perhaps in branch too to prove.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
