### PR TITLE
ACRS-167-Bugfix missing space

### DIFF
--- a/apps/acrs/translations/src/en/fields.json
+++ b/apps/acrs/translations/src/en/fields.json
@@ -408,7 +408,7 @@
     "label": "Address line 1"
   },
   "is-decision-post-address-2": {
-    "label": "Address line 2(optional)"
+    "label": "Address line 2 (optional)"
   },
   "is-decision-post-town-or-city": {
     "label": "Town or city"


### PR DESCRIPTION
- Postal address page - missing spacing between address 2 and (optional)

## What? 
[ACRS-167](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-167) - Postal address page - missing spacing
## Why? 
- There is a missing spacing between '2' and '(optional)'

## How? 
Added a space between the text

## Testing?
tested locally

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
