### PR TITLE
ACRS-169 add /your-email to summary

### DIFF
--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -57,15 +57,31 @@ module.exports = {
       },
       {
         steps: '/confirm-your-email',
+        // The sessionModel field for the email address associated with /confirm-your-email is 'user-email'
         field: 'confirm-your-email',
         parse: (list, req) => {
-          if (!req.sessionModel.get('steps').includes('/confirm-your-email')) {
+          if ( !req.sessionModel.get('steps').includes('/confirm-your-email')) {
             return null;
           }
-          return req.sessionModel.get('confirm-your-email') === 'yes' ?
-            `${req.sessionModel.get('user-email')}` :
-            `${req.sessionModel.get('your-email-address')}`;
+          return req.sessionModel.get('confirm-your-email') === 'yes' ? 'Yes' : 'No';
         }
+      },
+      {
+        steps: '/your-email',
+        field: 'your-email-options',
+        parse: (list, req) => {
+          if ( !req.sessionModel.get('steps').includes('/your-email')) {
+            return null;
+          }
+          return req.sessionModel.get('your-email-options') === 'yes' ? 'Yes' : 'No';
+        }
+      },
+      {
+        steps: '/your-email',
+        field: 'your-email-address',
+        parse: (list, req) => req.sessionModel.get('steps').includes('/your-email') ?
+          req.sessionModel.get('your-email-address') :
+          null
       },
       {
         step: '/provide-telephone-number',

--- a/apps/acrs/translations/src/en/pages.json
+++ b/apps/acrs/translations/src/en/pages.json
@@ -197,6 +197,12 @@
       "confirm-your-email": {
         "label": "Is this your email address?"
       },
+      "your-email-options": {
+        "label": "Do you have an email address?"
+      },
+      "your-email-address": {
+        "label": "Your email address"
+      },
       "provide-telephone-number": {
         "label": "Can you provide a telephone number?"
       },


### PR DESCRIPTION
## What? 

[ACRS-169 summary x3 email](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-169)

Add the `/your-email` option and address fields to the summary page.
