### PR TITLE
ACRS-154 Immigration Advisor Details page - remove additional H1

### DIFF
--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -538,7 +538,6 @@ module.exports = {
     }
   },
   'is-legal-representative-email': {
-    isPageHeading: true,
     mixin: 'radio-group',
     validate: ['required'],
     legend: {


### PR DESCRIPTION
## What? 

Remove the `isPageHeading` property from the `'is-legal-representative-email'` field.

## Why? 

This field is the last in a set of fields in the page, and its label should not be used to create the page heading (H1) - there is already a H1 level element in this page generated elsewhere.

Removing this field stops the label from being rendered as an additional H1 in the page.

## Screenshots (optional)

Before change (2 x H1):
<img width="1219" alt="before change 2 h1 elements" src="https://github.com/UKHomeOffice/acrs/assets/137879919/bc93dc0f-a652-40a4-8d70-498a5909ea5c">

After change (1 x H1):
<img width="1336" alt="after change 1 h1 element" src="https://github.com/UKHomeOffice/acrs/assets/137879919/45c958f2-47cf-490f-aa18-15e4cda8ac0c">

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
