### PR TITLE
ACRS-150: Add missing label to email address entry field in verify app

### DIFF
--- a/apps/verify/translations/src/en/fields.json
+++ b/apps/verify/translations/src/en/fields.json
@@ -25,6 +25,7 @@
     "hint": "{{values.brp-hint}}For example, 27 3 1985"
   },
   "user-email": {
+    "label": "Enter an email address",
     "hint": "We will email you a secure link, so you can save your information and return later."
   }
 }


### PR DESCRIPTION
## What? 

Add a label to the `"user-email"` field in the verify app.

## Why? 

The lack of label test was showing the object link to where the label would be instead of the actual label text. This could confuse users of screen readers as it does not give adequate instructions for the field

## Screenshots (optional)

Before label updated:
<img width="1025" alt="before label updated" src="https://github.com/UKHomeOffice/acrs/assets/137879919/b145cdeb-39c7-42c7-bcc8-5be9d467493f">

After label updated:
<img width="699" alt="after label updated" src="https://github.com/UKHomeOffice/acrs/assets/137879919/e48a65e8-117e-447e-8a9c-36d4825f3736">

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
