### PR TITLE
ACRS-103 Bugfix Error message for email

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,6 +10,14 @@ ignore:
     - '*':
         reason: notifications-node-client needs to be upgraded in HOF to latest version
         expires: '2024-09-15T00:00:00.000Z'
+  SNYK-JS-ASYNC-7414156:
+    - '*':
+        reason: Regular Expression Denial of Service (ReDoS) needs to be upgraded in HOF to latest version
+        expires: '2024-09-15T00:00:00.000Z'
+  SNYK-JS-AXIOS-6032459:
+    - '*':
+        reason: Cross-site Request Forgery (CSRF) needs to be upgraded in HOF to latest version
+        expires: '2024-09-15T00:00:00.000Z'
   SNYK-JS-SEMVER-3247795:
     - '*':
         reason: notifications-node-client needs to be upgraded in HOF to latest version
@@ -51,11 +59,6 @@ ignore:
     - jimp > @jimp/custom > @jimp/core > file-type:
         reason: No valid upgrade path
         expires: '2024-08-25T12:03:06.412Z'
-  SNYK-JS-AXIOS-6032459:
-    - '*':
-        reason: Update notifications-node-client in HOF
-        expires: '2024-07-03T00:00:00.000Z'
-        created: '2023-11-08T13:22:47.350Z'
   SNYK-JS-XML2JS-5414874:
     - '*':
         reason: No valid upgrade path

--- a/apps/verify/translations/src/en/validation.json
+++ b/apps/verify/translations/src/en/validation.json
@@ -21,6 +21,7 @@
   "user-email": {
     "required": "Enter your email address",
     "noRecordMatch": "Your email does not match the other details given. Please enter the correct email",
-    "email": "Enter a valid email address"
+    "email": "Enter a valid email address",
+    "errorMessage": "There is a problem with this service. Try again later"
   }
 }


### PR DESCRIPTION
## What?
[ACRS-103](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-103)

## Why? 
To allow error message display instead of 500 error page 

## How? 
- Removed the default error in the catch block in the send verification behaviour file allow a custom error render
- Added error message in the validation.js
- 
## Testing?
Tested manually 

## Screenshots (optional)
![Screenshot 2024-06-27 at 10 05 05](https://github.com/UKHomeOffice/acrs/assets/138882912/7c1bf2f3-2f09-4c35-9e0f-5000a56f785c)

## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
