### PR TITLE
ACRS-155 fix switch IA to helper

### DIFF
--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -69,7 +69,8 @@ module.exports = {
           condition: {
             field: 'who-completing-form',
             value: 'the-referrer'
-          }
+          },
+          continueOnEdit: true
         },
         {
           target: '/helper-details',
@@ -88,6 +89,7 @@ module.exports = {
       ],
       fields: ['who-completing-form'],
       locals: { showSaveAndExit: true },
+      continueOnEdit: true,
       next: '/helper-details'
     },
     '/helper-details': {


### PR DESCRIPTION
[ACRS-155 IA Switch Bug](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-155)

On `/information-you-have-given-us` page, when using the "Change" link of "Who is completing this form?",
the "Save and continue" button of `/who-completing-form` returned immediately to 
`/information-you-have-given-us` without the opportunity to add either a helper or immigration advisor.

This quick-fix for this was to add the `continueOnEdit` flag in the correct places to 
prevent `save-form-session` from immediately redirecting.

However, the `continueOnEdit` handling is not ideal for `/who-completing-form` which only requires 
onward editing for two of the three options.

The flaw in this quick-fix is that selecting "The referrer" option on `/who-completing-form` will 
unnecessarily re-visit `/full-name`. While this is low-risk it is not correct.