### PR TITLE
ACRS-149 Add mixin types to all date components in fields

### DIFF
--- a/apps/acrs/fields/index.js
+++ b/apps/acrs/fields/index.js
@@ -127,6 +127,7 @@ module.exports = {
     validate: ['email']
   },
   'partner-date-of-birth': dateComponent('partner-date-of-birth', {
+    mixin: 'input-date',
     legend: { className: 'bold' },
     validate: ['required', 'before', after1900Validator, 'over18']
   }),
@@ -175,6 +176,7 @@ module.exports = {
     labelClassName: 'bold'
   },
   'child-date-of-birth': dateComponent('child-date-of-birth', {
+    mixin: 'input-date',
     legend: { className: 'bold' },
     validate: [
       'required',
@@ -236,6 +238,7 @@ module.exports = {
     validate: ['email']
   },
   'parent-date-of-birth': dateComponent('parent-date-of-birth', {
+    mixin: 'input-date',
     legend: { className: 'bold' },
     validate: ['required', 'before', after1900Validator, 'over18']
   }),
@@ -273,6 +276,7 @@ module.exports = {
     labelClassName: 'bold'
   },
   'brother-or-sister-date-of-birth': dateComponent('brother-or-sister-date-of-birth', {
+    mixin: 'input-date',
     legend: { className: 'bold' },
     validate: [
       'required',
@@ -313,6 +317,7 @@ module.exports = {
     labelClassName: 'bold'
   },
   'additional-family-date-of-birth': dateComponent('additional-family-date-of-birth', {
+    mixin: 'input-date',
     legend: { className: 'bold' },
     validate: ['required', 'before', after1900Validator]
   }),
@@ -385,6 +390,7 @@ module.exports = {
     className: ['govuk-input', 'govuk-!-width-two-thirds']
   },
   'family-member-date-of-birth': dateComponent('family-member-date-of-birth', {
+    mixin: 'input-date',
     legend: {
       className: 'bold'
     },

--- a/apps/verify/fields/index.js
+++ b/apps/verify/fields/index.js
@@ -20,6 +20,7 @@ module.exports = {
     labelClassName: 'bold'
   },
   'date-of-birth': dateComponent('date-of-birth', {
+    mixin: 'input-date',
     legend: {
       className: 'bold'
     },


### PR DESCRIPTION
## What?

[ACRS-149](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-149)
Add `mixin: 'input-date'` to all date component fields.
 
## Why? 

Adding the mixin type to the date component fields fixes an issue where links moving focus from error summary to erroring field are broken in the case of dates.

This was reported as an accessibility issue.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
