### PR TITLE
ACRS-70 Change timeout message

### DIFF
--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -667,10 +667,6 @@ module.exports = {
       clearSession: true,
       backLink: false
     },
-    '/session-expired': {
-      fields: [],
-      next: '/confirm'
-    },
     '/link-expired': {
       fields: [],
       next: '/confirm'

--- a/apps/acrs/translations/src/en/buttons.json
+++ b/apps/acrs/translations/src/en/buttons.json
@@ -10,5 +10,6 @@
     "confirm-submission": "Submit",
     "continue-only": "Continue",
     "enter-form": "Enter form",
-    "exit": "Exit"
+    "exit": "Exit",
+    "start-again": "Sign in again"
 }

--- a/apps/acrs/translations/src/en/errors.json
+++ b/apps/acrs/translations/src/en/errors.json
@@ -1,0 +1,6 @@
+{
+    "session": {
+        "title": "We saved your information and signed you out",
+        "message": "We signed you out to keep your information secure. We did this because you did not do anything for 30 minutes. We saved your answers from the last completed page. Sign in again to continue your form."
+      }
+}

--- a/apps/verify/translations/src/en/buttons.json
+++ b/apps/verify/translations/src/en/buttons.json
@@ -5,5 +5,6 @@
   "generate": "Generate",
   "resend-email": "Resend email",
   "delete": "Delete",
-  "start-home": "Start now"
+  "start-home": "Start now",
+  "start-again": "Sign in again"
 }

--- a/apps/verify/translations/src/en/errors.json
+++ b/apps/verify/translations/src/en/errors.json
@@ -1,0 +1,6 @@
+{
+    "session": {
+        "title": "We saved your information and signed you out",
+        "message": "We signed you out to keep your information secure. We did this because you did not do anything for 30 minutes. We saved your answers from the last completed page. Sign in again to continue your form."
+      }
+}


### PR DESCRIPTION
## What? 
[ACRS-70](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-70) - Change content of timeout message

## Why? 
To allow display a different timeout message rather than the defined hof framework message 

## How? 
- Added error.json in the translation folder for both acrs and verify with the custom text
- 
## Testing?
Tested locally 

## Screenshots (optional)
![Screenshot 2024-07-01 at 10 20 53](https://github.com/UKHomeOffice/acrs/assets/138882912/1464f97a-81b1-4a70-9c58-40ed3cfea283)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
