### PR TITLE
ACRS-131: Fix loading UAN based form when verified with BRP and vice versa

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -101,7 +101,7 @@ ignore:
       reason: No upgrade or patch available
       expires: '2024-08-13T00:00:00.000Z'
   SNYK-JS-ASYNC-7414156:
-    - winston > async:
+    - '*':
       reason: No upgrade or patch available
       expires: '2024-10-03T00:00:00.000Z'
       created: '2024-07-03T10:50:47.350Z'

--- a/.snyk
+++ b/.snyk
@@ -54,7 +54,7 @@ ignore:
   SNYK-JS-AXIOS-6032459:
     - '*':
         reason: Update notifications-node-client in HOF
-        expires: '2024-07-03T00:00:00.000Z'
+        expires: '2024-10-03T00:00:00.000Z'
         created: '2023-11-08T13:22:47.350Z'
   SNYK-JS-XML2JS-5414874:
     - '*':
@@ -100,4 +100,9 @@ ignore:
     - '*':
       reason: No upgrade or patch available
       expires: '2024-08-13T00:00:00.000Z'
+  SNYK-JS-ASYNC-7414156:
+    - winston > async:
+      reason: No upgrade or patch available
+      expires: '2024-10-03T00:00:00.000Z'
+      created: '2024-07-03T10:50:47.350Z'
 patch: {}

--- a/apps/acrs/behaviours/resume-form-session.js
+++ b/apps/acrs/behaviours/resume-form-session.js
@@ -37,8 +37,11 @@ module.exports = superclass => class extends superclass {
 
     return axios.get(baseUrl + encodeEmail(email))
       .then(response => {
-        const unsubmittedCases = _.filter(response.data, record => !record.submitted_at);
-        const cases = this.parseCasesSessions(unsubmittedCases);
+        const sessionCases = req.sessionModel.get('user-cases') || [];
+        const unsubmittedCases = _.filter(response.data, record => !record.submitted_at );
+        const parsedBody = this.parseCasesSessions(unsubmittedCases);
+        const cases = _.unionBy(parsedBody, sessionCases, 'id');
+
         const uan = req.sessionModel.get('uan');
         const brp = req.sessionModel.get('brp');
         let isSameCase = '';

--- a/db/save-token.js
+++ b/db/save-token.js
@@ -17,6 +17,7 @@ module.exports = {
     redis.expire(`${token}:email`, tokenExpiry);
     redis.expire(`${token}:brp`, tokenExpiry);
     redis.expire(`${token}:uan`, tokenExpiry);
+    redis.expire(`${token}:sign-in-method`, tokenExpiry);
     redis.expire(`${token}:date-of-birth`, tokenExpiry);
 
     return token;


### PR DESCRIPTION
## What? 

Fixed bug [ACRS-131](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-131) where if a user logs in to the form using a BRP number, has multiple referrals against their email address, then selects to continue with a form started with a UAN the app will throw an error.

Simplified the session creation behaviour so that it only pulls the latest referrals stored against a user (plus a new referral if relevant) rather than bringing back previous session stored data which is not needed.

Ensured that when a user selects a form the session data from login is overwritten by the stored data, so that login data for one referrer doesn't bleed into other referrers form data when switching between referrals.

## Why?

The bug stops anyone who attempts to work on a referral that was originally started by verifying with the opposite ID type. This would be confusing to users as they would expect to be able to continue any referral offered in the list of incomplete referrals without error.

## How? 

The behaviour was only allowing a session to be built where data was available for the id-type signed in with. This has been replaced with an either/or situation allowing the session to build for either data type.

Added some specific session value setting in the setup session function so that if a user logs in with some data, but continues a separate referral, the login data is not accidentally added to the stored session for the referral to be continued.

## Testing?

Tested locally, could do with testing on branch before merge.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
