### PR TITLE
ACRS-185 Summary Change Routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ output/
 anchore-reports
 .nyc_output
 .vscode
+*.code-workspace
 dump.rdb
 yarn-error.log
 apps/**/translations/**/*

--- a/apps/acrs/behaviours/aggregator-save-update.js
+++ b/apps/acrs/behaviours/aggregator-save-update.js
@@ -70,7 +70,7 @@ module.exports = superclass => class extends superclass {
         changeField: aggregateFromElement.changeField
       });
 
-      this.setAggregateArray(req, items);
+      this.setAggregateArray(req, items); // should this be (req, fields) ?
       req.sessionModel.unset(aggregateFromField);
     });
 

--- a/apps/acrs/behaviours/aggregator-save-update.js
+++ b/apps/acrs/behaviours/aggregator-save-update.js
@@ -4,7 +4,7 @@ module.exports = superclass => class extends superclass {
       throw new Error('options.aggregateTo is required for loops');
     }
     if (!options.aggregateFrom) {
-      throw new Error('options.aggregateField is required for loops');
+      throw new Error('options.aggregateFrom is required for loops');
     }
     super(options);
   }

--- a/apps/acrs/behaviours/continue-report.js
+++ b/apps/acrs/behaviours/continue-report.js
@@ -64,7 +64,7 @@ module.exports = superclass => class extends superclass {
       if (err) {
         next(err);
       }
-      req.sessionModel.set('redirect-to-information-you-have-given-us', false);
+      req.sessionModel.unset('redirect-to-information-you-have-given-us');
 
       return res.redirect(`/acrs${req.sessionModel.get('save-return-next-step')}`);
     });

--- a/apps/acrs/behaviours/edit-route-return.js
+++ b/apps/acrs/behaviours/edit-route-return.js
@@ -1,4 +1,4 @@
-// This behaviour will redirect the route back to the Summary page that set the edit-return-path url.
+// This behaviour will redirect the route back to the Summary page that set the Edit-mode url in edit-return-path.
 module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     super.saveValues(req, res, err => {

--- a/apps/acrs/behaviours/edit-route-return.js
+++ b/apps/acrs/behaviours/edit-route-return.js
@@ -1,4 +1,4 @@
-// This behaviour will redirect the route back to a summary page the set the Edit-mode url.
+// This behaviour will redirect the route back to the Summary page that set the edit-return-path url.
 module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     super.saveValues(req, res, err => {

--- a/apps/acrs/behaviours/edit-route-return.js
+++ b/apps/acrs/behaviours/edit-route-return.js
@@ -1,0 +1,35 @@
+// This behaviour will redirect the route back to a summary page the set the Edit-mode url.
+module.exports = superclass => class extends superclass {
+  saveValues(req, res, next) {
+    super.saveValues(req, res, err => {
+      if (err) {
+        next(err);
+      }
+
+      const shouldContinueOnEdit = this.isContinueOnEdit(req.form.options, req.form.values);
+      const editReturnPath = req.sessionModel.get('edit-return-path');
+      if (!shouldContinueOnEdit && editReturnPath) {
+        return res.redirect(editReturnPath);
+      }
+      return next();
+    });
+  }
+
+  /**
+   * Checks if continueOnEdit is set on the form or on the selected fork
+   *
+   * @param {Object} formOptions - The form configuration (options), typically matching index.js/steps
+   * @param {Object} formValues - The form input values, typically from the request as { field: 'value', ... }
+   * @return {boolean} true if the form should continue on edit
+   */
+  isContinueOnEdit(formOptions, formValues) {
+    if (formOptions.continueOnEdit) {
+      return true;
+    }
+
+    const chosenOption = formOptions.forks?.find(fork => {
+      return formValues[fork.condition.field] === fork.condition.value;
+    });
+    return Boolean(chosenOption && chosenOption.continueOnEdit);
+  }
+};

--- a/apps/acrs/behaviours/edit-route-return.js
+++ b/apps/acrs/behaviours/edit-route-return.js
@@ -8,7 +8,7 @@ module.exports = superclass => class extends superclass {
 
       const shouldContinueOnEdit = this.isContinueOnEdit(req);
       const editReturnPath = req.sessionModel.get('edit-return-path');
-      if (!shouldContinueOnEdit && editReturnPath) {
+      if ( !shouldContinueOnEdit && editReturnPath) {
         return res.redirect(editReturnPath);
       }
       return next();

--- a/apps/acrs/behaviours/edit-route-return.js
+++ b/apps/acrs/behaviours/edit-route-return.js
@@ -6,7 +6,7 @@ module.exports = superclass => class extends superclass {
         next(err);
       }
 
-      const shouldContinueOnEdit = this.isContinueOnEdit(req.form.options, req.form.values);
+      const shouldContinueOnEdit = this.isContinueOnEdit(req);
       const editReturnPath = req.sessionModel.get('edit-return-path');
       if (!shouldContinueOnEdit && editReturnPath) {
         return res.redirect(editReturnPath);
@@ -17,19 +17,24 @@ module.exports = superclass => class extends superclass {
 
   /**
    * Checks if continueOnEdit is set on the form or on the selected fork
-   *
-   * @param {Object} formOptions - The form configuration (options), typically matching index.js/steps
-   * @param {Object} formValues - The form input values, typically from the request as { field: 'value', ... }
-   * @return {boolean} true if the form should continue on edit
    */
-  isContinueOnEdit(formOptions, formValues) {
-    if (formOptions.continueOnEdit) {
+  isContinueOnEdit(req) {
+    if (req.form.options.continueOnEdit) {
       return true;
     }
-
-    const chosenOption = formOptions.forks?.find(fork => {
-      return formValues[fork.condition.field] === fork.condition.value;
+    const chosenOption = req.form.options.forks?.find(fork => {
+      return fork.condition && this.isForkSelected(fork.condition, req);
     });
     return Boolean(chosenOption && chosenOption.continueOnEdit);
+  }
+
+  /*
+   * Check if the conditions of the fork are met
+  */
+  isForkSelected(condition, req) {
+    if (typeof condition === 'function') {
+      return condition(req);
+    }
+    return req.form.values[condition.field] === condition.value;
   }
 };

--- a/apps/acrs/behaviours/edit-route-start.js
+++ b/apps/acrs/behaviours/edit-route-start.js
@@ -4,7 +4,7 @@
 // the summary page.
 module.exports = superclass => class extends superclass {
   getValues(req, res, next) {
-    req.sessionModel.set('edit-return-path', req.path);
+    req.sessionModel.set('edit-return-path', req.originalUrl);
     return super.getValues(req, res, next);
   }
 

--- a/apps/acrs/behaviours/edit-route-start.js
+++ b/apps/acrs/behaviours/edit-route-start.js
@@ -1,0 +1,15 @@
+// This behaviour captures the return from Edit-mode url.
+// Edit-mode is entered by clicking a Change link on a summary page and
+// signals that routing will return from the changed (edited) page to
+// the summary page.
+module.exports = superclass => class extends superclass {
+  getValues(req, res, next) {
+    req.sessionModel.set('edit-return-path', req.path);
+    return super.getValues(req, res, next);
+  }
+
+  saveValues(req, res, next) {
+    req.sessionModel.unset('edit-return-path');
+    return super.saveValues(req, res, next);
+  }
+};

--- a/apps/acrs/behaviours/family-in-uk-summary.js
+++ b/apps/acrs/behaviours/family-in-uk-summary.js
@@ -6,7 +6,7 @@ module.exports = superclass => class extends superclass {
 
     // When all family member in uk  are removed redirect to the loop section intro
     if(aggregate && !aggregate.aggregatedValues.length) {
-      req.form.options.addStep = 'family-in-uk-details';
+      req.form.options.addStep = 'family-in-uk';
     }
     super.configure(req, res, next);
   }

--- a/apps/acrs/behaviours/limit-family-in-uk.js
+++ b/apps/acrs/behaviours/limit-family-in-uk.js
@@ -2,8 +2,8 @@ module.exports = superclass => class extends superclass {
   locals(req, res) {
     const locals = super.locals(req, res);
     locals.familyMemberCount = '1';
-    if(req.sessionModel.get('family-member-in-uk') !== undefined) {
-      const familyMembers = req.sessionModel.get('family-member-in-uk').aggregatedValues;
+    if(req.sessionModel.get('uk-family-aggregate') !== undefined) {
+      const familyMembers = req.sessionModel.get('uk-family-aggregate').aggregatedValues;
       const familyMemberLimit = familyMembers.length >= req.form.options.aggregateLimit;
       const familyMemberCount = familyMembers.length + 1;
 

--- a/apps/acrs/behaviours/reset-summary.js
+++ b/apps/acrs/behaviours/reset-summary.js
@@ -1,5 +1,6 @@
 'use strict';
-
+// This behaviour removes a Section's aggregated values from the session if the user has
+// changed the selection to 'no' in the Section start field
 module.exports = (aggregateToField, sectionStartField) => superclass => class extends superclass {
   saveValues(req, res, next) {
     if(req.sessionModel.get(aggregateToField) !== undefined) {

--- a/apps/acrs/behaviours/reset-summary.js
+++ b/apps/acrs/behaviours/reset-summary.js
@@ -1,9 +1,14 @@
 'use strict';
 // This behaviour removes a Section's aggregated values from the session if the user has
-// changed the selection to 'no' in the Section start field
+// changed the selection to 'no' in the Section start field.
 module.exports = (aggregateToField, sectionStartField) => superclass => class extends superclass {
   saveValues(req, res, next) {
     if(req.sessionModel.get(aggregateToField) !== undefined) {
+      // Note that logic here checks the sessionModel not the form.values.
+      // `form.values` is the current value of the form just submitted.
+      // `sessionModel` holds the values the previous time the form was submitted.
+      // Subsequently the aggregation will only be removed from the session
+      // when the form was switched to 'no' on the previous post (Save and continue).
       if(req.sessionModel.get(sectionStartField) === 'no' &&
       req.sessionModel.get(aggregateToField).aggregatedValues.length > 0) {
         req.sessionModel.unset(aggregateToField);

--- a/apps/acrs/behaviours/save-form-session.js
+++ b/apps/acrs/behaviours/save-form-session.js
@@ -4,8 +4,8 @@ const axios = require('axios');
 const config = require('../../../config');
 const _ = require('lodash');
 
-
 const applicationsUrl = `${config.saveService.host}:${config.saveService.port}/saved_applications`;
+
 
 module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
@@ -63,9 +63,14 @@ module.exports = superclass => class extends superclass {
           return res.redirect('/sign-in');
         }
 
-        const isContinueOnEdit = req.form.options.continueOnEdit &&
-          _.get(req.form.options.forks, '[0].continueOnEdit');
+        // continueOnEdit can be set on the form or on individual forks
+        const isContinueOnEdit = this.isChoiceContinueOnEdit(req.form.options, req.form.values);
 
+        // const isContinueOnEdit = req.form.options.continueOnEdit &&
+        // _.get(req.form.options.forks, '[0].continueOnEdit');
+
+        // The assumption here is when there is a fork in the form
+        // then its first entry is the only route into a looped section
         const loopedForkCondition = _.get(req.form.options.forks, '[0].condition.value');
         const loopedForkField = _.get(req.form.options.forks, '[0].condition.field');
         const loopedFieldMatchesForkCondition = loopedForkField &&
@@ -81,5 +86,23 @@ module.exports = superclass => class extends superclass {
         return next(e);
       }
     });
+  }
+
+  /**
+   * Checks if continueOnEdit is set on the form or on the selected fork
+   *
+   * @param {Object} formOptions - The form configuration (options), typically matching index.js/steps
+   * @param {Object} formValues - The form input values, typically from the request as { field: 'value', ... }
+   * @return {boolean} true if the form should continue on edit
+   */
+  isChoiceContinueOnEdit(formOptions, formValues) {
+    if (formOptions.continueOnEdit) {
+      return true;
+    }
+
+    const chosenOption = formOptions.forks?.find(fork => {
+      return formValues[fork.condition.field] === fork.condition.value;
+    });
+    return Boolean(chosenOption && chosenOption.continueOnEdit);
   }
 };

--- a/apps/acrs/behaviours/save-form-session.js
+++ b/apps/acrs/behaviours/save-form-session.js
@@ -5,7 +5,6 @@ const config = require('../../../config');
 
 const applicationsUrl = `${config.saveService.host}:${config.saveService.port}/saved_applications`;
 
-
 module.exports = superclass => class extends superclass {
   saveValues(req, res, next) {
     return super.saveValues(req, res, async err => {

--- a/apps/acrs/behaviours/save-form-session.js
+++ b/apps/acrs/behaviours/save-form-session.js
@@ -63,46 +63,10 @@ module.exports = superclass => class extends superclass {
           return res.redirect('/sign-in');
         }
 
-        // continueOnEdit can be set on the form or on individual forks
-        const isContinueOnEdit = this.isChoiceContinueOnEdit(req.form.options, req.form.values);
-
-        // const isContinueOnEdit = req.form.options.continueOnEdit &&
-        // _.get(req.form.options.forks, '[0].continueOnEdit');
-
-        // The assumption here is when there is a fork in the form
-        // then its first entry is the only route into a looped section
-        const loopedForkCondition = _.get(req.form.options.forks, '[0].condition.value');
-        const loopedForkField = _.get(req.form.options.forks, '[0].condition.field');
-        const loopedFieldMatchesForkCondition = loopedForkField &&
-          req.form.values[loopedForkField] === loopedForkCondition;
-
-        if (req.sessionModel.get('redirect-to-information-you-have-given-us') &&
-          !isContinueOnEdit && !loopedFieldMatchesForkCondition) {
-          return res.redirect('/acrs/information-you-have-given-us');
-        }
-
         return next();
       } catch (e) {
         return next(e);
       }
     });
-  }
-
-  /**
-   * Checks if continueOnEdit is set on the form or on the selected fork
-   *
-   * @param {Object} formOptions - The form configuration (options), typically matching index.js/steps
-   * @param {Object} formValues - The form input values, typically from the request as { field: 'value', ... }
-   * @return {boolean} true if the form should continue on edit
-   */
-  isChoiceContinueOnEdit(formOptions, formValues) {
-    if (formOptions.continueOnEdit) {
-      return true;
-    }
-
-    const chosenOption = formOptions.forks?.find(fork => {
-      return formValues[fork.condition.field] === fork.condition.value;
-    });
-    return Boolean(chosenOption && chosenOption.continueOnEdit);
   }
 };

--- a/apps/acrs/behaviours/save-form-session.js
+++ b/apps/acrs/behaviours/save-form-session.js
@@ -2,7 +2,6 @@
 
 const axios = require('axios');
 const config = require('../../../config');
-const _ = require('lodash');
 
 const applicationsUrl = `${config.saveService.host}:${config.saveService.port}/saved_applications`;
 

--- a/apps/acrs/behaviours/summary-modify-change-link.js
+++ b/apps/acrs/behaviours/summary-modify-change-link.js
@@ -4,13 +4,13 @@ const _ = require('lodash');
 
 const remapChangeLinks = (fields, mappings) => {
   _.forEach(fields, field => {
-    const mapping = mappings.find(mapping => mapping.field === field.field);
-    if (mapping) {
-      field.changeLink = mapping.changeLink;
+    const remap = mappings.find(mapping => mapping.field === field.field);
+    if (remap) {
+      field.changeLink = remap.changeLink;
     }
   });
   return fields;
-}
+};
 const remapQuestionLinks = (fields, mappings) => {
   _.forEach(fields, field => {
     if (mappings.includes(field.field)) {
@@ -18,7 +18,7 @@ const remapQuestionLinks = (fields, mappings) => {
     }
   });
   return fields;
-}
+};
 
 module.exports = superclass => class extends superclass {
   locals(req, res) {
@@ -26,20 +26,19 @@ module.exports = superclass => class extends superclass {
     // set change link for looping summary fields
     if (locals.route === 'information-you-have-given-us' || locals.route === 'confirm') {
       _.forEach(locals.rows, section => {
-
         if (section.section === 'Family in your referral') {
-          // Fixup the "Change" link urls for the aggregate Title fields 
+          // Fixup the "Change" link urls for the aggregate Title fields
           // so that the link jumps to the aggregate's summary page
           const summaryMappings = [
-            { 'field': 'parent-full-name', 'changeLink': '/acrs/parent-summary' },
-            { 'field': 'brother-or-sister-full-name', 'changeLink': '/acrs/brother-or-sister-summary' },
-            { 'field': 'child-full-name', 'changeLink': '/acrs/children-summary' },
-            { 'field': 'additional-family-full-name', 'changeLink': '/acrs/additional-family-summary' },
-            { 'field': 'partner-full-name', 'changeLink': '/acrs/partner-summary' },
+            { field: 'parent-full-name', changeLink: '/acrs/parent-summary' },
+            { field: 'brother-or-sister-full-name', changeLink: '/acrs/brother-or-sister-summary' },
+            { field: 'child-full-name', changeLink: '/acrs/children-summary' },
+            { field: 'additional-family-full-name', changeLink: '/acrs/additional-family-summary' },
+            { field: 'partner-full-name', changeLink: '/acrs/partner-summary' }
           ];
           section.fields = remapChangeLinks(section.fields, summaryMappings);
 
-          // Fixup the "Change" link urls for the aggregate Question fields 
+          // Fixup the "Change" link urls for the aggregate Question fields
           // so that the link jumps to the aggregate's Question page without /edit
           const questionMappings = ['partner', 'children', 'additional-family'];
           section.fields = remapQuestionLinks(section.fields, questionMappings);
@@ -47,8 +46,8 @@ module.exports = superclass => class extends superclass {
 
         if (section.section === 'Family that live in the UK') {
           const mappings = [
-            { 'field': 'family-in-uk', 'changeLink': '/acrs/family-in-uk' },
-            { 'field': 'family-member-fullname', 'changeLink': '/acrs/family-in-uk-summary' },
+            { field: 'family-in-uk', changeLink: '/acrs/family-in-uk' },
+            { field: 'family-member-fullname', changeLink: '/acrs/family-in-uk-summary' }
           ];
           section.fields = remapChangeLinks(section.fields, mappings);
         }

--- a/apps/acrs/behaviours/summary-modify-change-link.js
+++ b/apps/acrs/behaviours/summary-modify-change-link.js
@@ -11,6 +11,14 @@ const remapChangeLinks = (fields, mappings) => {
   });
   return fields;
 }
+const remapQuestionLinks = (fields, mappings) => {
+  _.forEach(fields, field => {
+    if (mappings.includes(field.field)) {
+      field.changeLink = field.changeLink.replace('/edit', '');
+    }
+  });
+  return fields;
+}
 
 module.exports = superclass => class extends superclass {
   locals(req, res) {
@@ -19,18 +27,24 @@ module.exports = superclass => class extends superclass {
     if (locals.route === 'information-you-have-given-us' || locals.route === 'confirm') {
       _.forEach(locals.rows, section => {
 
-        // Fixup the "Change" link urls for the aggregate Title fields 
-        // so that the link jumps to the aggregate's summary page
         if (section.section === 'Family in your referral') {
-          const mappings = [
+          // Fixup the "Change" link urls for the aggregate Title fields 
+          // so that the link jumps to the aggregate's summary page
+          const summaryMappings = [
             { 'field': 'parent-full-name', 'changeLink': '/acrs/parent-summary' },
             { 'field': 'brother-or-sister-full-name', 'changeLink': '/acrs/brother-or-sister-summary' },
             { 'field': 'child-full-name', 'changeLink': '/acrs/children-summary' },
             { 'field': 'additional-family-full-name', 'changeLink': '/acrs/additional-family-summary' },
             { 'field': 'partner-full-name', 'changeLink': '/acrs/partner-summary' },
           ];
-          section.fields = remapChangeLinks(section.fields, mappings);
+          section.fields = remapChangeLinks(section.fields, summaryMappings);
+
+          // Fixup the "Change" link urls for the aggregate Question fields 
+          // so that the link jumps to the aggregate's Question page without /edit
+          const questionMappings = ['partner', 'children', 'additional-family'];
+          section.fields = remapQuestionLinks(section.fields, questionMappings);
         }
+
         if (section.section === 'Family that live in the UK') {
           const mappings = [
             { 'field': 'family-in-uk', 'changeLink': '/acrs/family-in-uk' },

--- a/apps/acrs/behaviours/summary-modify-change-link.js
+++ b/apps/acrs/behaviours/summary-modify-change-link.js
@@ -1,46 +1,43 @@
 'use strict';
-
+// This behaviour is used to set the "Change" links on Summary pages
 const _ = require('lodash');
+
+const remapChangeLinks = (fields, mappings) => {
+  _.forEach(fields, field => {
+    const mapping = mappings.find(mapping => mapping.field === field.field);
+    if (mapping) {
+      field.changeLink = mapping.changeLink;
+    }
+  });
+  return fields;
+}
 
 module.exports = superclass => class extends superclass {
   locals(req, res) {
     const locals = super.locals(req, res);
     // set change link for looping summary fields
     if (locals.route === 'information-you-have-given-us' || locals.route === 'confirm') {
-      _.forEach(locals.rows, fields => {
-        locals.rows = locals.rows.map(row => {
-          // Add new section blocks as aggregator summaries are added
-          if (row.section === 'Family in your referral') {
-            _.forEach(fields, sectionFields => {
-              _.forEach(sectionFields, field => {
-                if (field.field === 'parent-full-name') {
-                  field.changeLink = '/acrs/parent-summary';
-                }
-                if (field.field === 'brother-or-sister-full-name') {
-                  field.changeLink = '/acrs/brother-or-sister-summary';
-                }
-                if (field.field === 'child-full-name') {
-                  field.changeLink = '/acrs/children-summary';
-                }
-                if (field.field === 'additional-family-full-name') {
-                  field.changeLink = '/acrs/additional-family-summary';
-                }
-                if (field.field === 'family-in-uk') {
-                  field.changeLink = '/acrs/family-in-uk';
-                }
-                if (field.field === 'family-member-fullname') {
-                  field.changeLink = '/acrs/family-in-uk-summary';
-                }
-                if (field.field === 'partner-full-name') {
-                  field.changeLink = '/acrs/partner-summary';
-                }
-              });
-            });
-            return row;
-          }
-          // end section block
-          return row;
-        });
+      _.forEach(locals.rows, section => {
+
+        // Fixup the "Change" link urls for the aggregate Title fields 
+        // so that the link jumps to the aggregate's summary page
+        if (section.section === 'Family in your referral') {
+          const mappings = [
+            { 'field': 'parent-full-name', 'changeLink': '/acrs/parent-summary' },
+            { 'field': 'brother-or-sister-full-name', 'changeLink': '/acrs/brother-or-sister-summary' },
+            { 'field': 'child-full-name', 'changeLink': '/acrs/children-summary' },
+            { 'field': 'additional-family-full-name', 'changeLink': '/acrs/additional-family-summary' },
+            { 'field': 'partner-full-name', 'changeLink': '/acrs/partner-summary' },
+          ];
+          section.fields = remapChangeLinks(section.fields, mappings);
+        }
+        if (section.section === 'Family that live in the UK') {
+          const mappings = [
+            { 'field': 'family-in-uk', 'changeLink': '/acrs/family-in-uk' },
+            { 'field': 'family-member-fullname', 'changeLink': '/acrs/family-in-uk-summary' },
+          ];
+          section.fields = remapChangeLinks(section.fields, mappings);
+        }
       });
     }
     return locals;

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -189,8 +189,8 @@ module.exports = {
 
     '/parent': {
       behaviours: [
-        ResetSummary('referred-parents', 'parent'), 
-        SaveFormSession, 
+        ResetSummary('referred-parents', 'parent'),
+        SaveFormSession,
         EditRouteReturn
       ],
       fields: ['parent'],
@@ -221,11 +221,11 @@ module.exports = {
               return true;
             }
             return false;
-          }
+          },
+          continueOnEdit: true
         }
       ],
-      locals: { showSaveAndExit: true },
-      continueOnEdit: true
+      locals: { showSaveAndExit: true }
     },
     '/parent-details': {
       behaviours: [LimitParents, SaveFormSession],
@@ -238,11 +238,16 @@ module.exports = {
         'parent-evacuated-without-reason'
       ],
       next: '/parent-summary',
-      locals: { showSaveAndExit: true },
-      continueOnEdit: true
+      locals: { showSaveAndExit: true }
     },
     '/parent-summary': {
-      behaviours: [AggregateSaveUpdate, ParentSummary, LimitParents, SaveFormSession],
+      behaviours: [
+        AggregateSaveUpdate,
+        ParentSummary,
+        LimitParents,
+        SaveFormSession,
+        EditRouteReturn
+      ],
       aggregateTo: 'referred-parents',
       aggregateFrom: [
         'parent-full-name',
@@ -264,7 +269,11 @@ module.exports = {
     },
 
     '/brother-or-sister': {
-      behaviours: [ResetSummary('referred-siblings', 'brother-or-sister'), SaveFormSession],
+      behaviours: [
+        ResetSummary('referred-siblings', 'brother-or-sister'),
+        SaveFormSession,
+        EditRouteReturn
+      ],
       fields: ['brother-or-sister'],
       forks: [
         {
@@ -272,7 +281,8 @@ module.exports = {
           condition: {
             field: 'brother-or-sister',
             value: 'yes'
-          }
+          },
+          continueOnEdit: true
         },
         {
           target: '/additional-family',
@@ -292,11 +302,11 @@ module.exports = {
               return true;
             }
             return false;
-          }
+          },
+          continueOnEdit: true
         }
       ],
-      locals: { showSaveAndExit: true },
-      continueOnEdit: true
+      locals: { showSaveAndExit: true }
     },
 
     '/brother-or-sister-details': {
@@ -308,11 +318,16 @@ module.exports = {
         'brother-or-sister-evacuated-without-reason'
       ],
       next: '/brother-or-sister-summary',
-      locals: { showSaveAndExit: true },
-      continueOnEdit: true
+      locals: { showSaveAndExit: true }
     },
     '/brother-or-sister-summary': {
-      behaviours: [AggregateSaveUpdate, BrotherSisterSummary, LimitBrothersOrSisters, SaveFormSession],
+      behaviours: [
+        AggregateSaveUpdate,
+        BrotherSisterSummary,
+        LimitBrothersOrSisters,
+        SaveFormSession,
+        EditRouteReturn
+      ],
       aggregateTo: 'referred-siblings',
       aggregateFrom: [
         'brother-or-sister-full-name',

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -602,44 +602,48 @@ module.exports = {
 
     '/family-in-uk': {
       behaviours: [
-        ResetSummary('uk-family-aggregate', 'family-in-uk'),
-        SaveFormSession
-      ],
-      forks: [
-        {
-          target: '/family-in-uk-details',
-          condition: {
-            field: 'has-family-in-uk',
-            value: 'yes'
-          }
-        },
-        {
-          target: '/upload-evidence',
-          condition: {
-            field: 'has-family-in-uk',
-            value: 'no'
-          }
-        }
+        ResetSummary('uk-family-aggregate', 'has-family-in-uk'),
+        SaveFormSession,
+        EditRouteReturn
       ],
       fields: ['has-family-in-uk'],
+      forks: [
+        {
+          target: '/family-in-uk-summary',
+          condition: req => yesPlusAggregation(req, 'has-family-in-uk', 'family-member-in-uk'),
+          continueOnEdit: true
+        },
+        {
+          target: '/family-in-uk-details',
+          condition: req => yesEmptyAggregation(req, 'has-family-in-uk', 'family-member-in-uk'),
+          continueOnEdit: true
+        }
+      ],
       locals: { showSaveAndExit: true },
-      next: '/family-in-uk-details'
+      next: '/upload-evidence'
     },
     '/family-in-uk-details': {
-      behaviours: [SaveFormSession, limitFamilyInUk],
+      behaviours: [SaveFormSession, limitFamilyInUk, EditRouteReturn],
       fields: [
         'family-member-fullname',
         'family-member-date-of-birth',
         'family-member-relationship',
         'has-family-member-been-evacuated'
       ],
+      continueOnEdit: true,
       backLink: 'family-in-uk',
       next: '/family-in-uk-summary',
       locals: { showSaveAndExit: true },
       titleField: 'countryAddNumber'
     },
     '/family-in-uk-summary': {
-      behaviours: [AggregateSaveUpdate, limitFamilyInUk, familyInUkSummary, SaveFormSession],
+      behaviours: [
+        AggregateSaveUpdate,
+        limitFamilyInUk,
+        familyInUkSummary,
+        SaveFormSession,
+        EditRouteReturn
+      ],
       aggregateTo: 'uk-family-aggregate',
       aggregateFrom: [
         'family-member-fullname',
@@ -653,7 +657,7 @@ module.exports = {
       template: 'family-in-uk-summary',
       locals: { showSaveAndExit: true },
       aggregateLimit: Utilities.DEFAULT_AGGREGATOR_LIMIT,
-      continueOnEdit: true,
+      continueOnEdit: false,
       next: '/upload-evidence'
     },
 

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -76,6 +76,24 @@ const yesEmptyAggregation = (req, formValue, aggregateName) => {
   return false;
 };
 
+/**
+ * 'no-family-referred' occurs when:
+ * - an >18 has not referred any Partner, Children or Additional Family
+ * - an <18 has not referred any Parent, Brother or Sister or Additional Family
+ * 
+ * @return {boolean} True if no family members are referred
+ */
+const noFamilyReferred = (req) => {
+  if (Utilities.isOver18(req.sessionModel.get('date-of-birth'))) {
+    return (req.sessionModel.get('partner') === 'no' &&
+      req.sessionModel.get('children') === 'no' &&
+      req.sessionModel.get('additional-family') === 'no');
+  }
+  return (req.sessionModel.get('parent') === 'no' &&
+    req.sessionModel.get('brother-or-sister') === 'no' &&
+    req.sessionModel.get('additional-family') === 'no');
+}
+
 
 module.exports = {
   name: 'acrs',
@@ -526,19 +544,7 @@ module.exports = {
         },
         {
           target: '/no-family-referred',
-          // 'no-family-referred' occurs when:
-          //  - an >18 has not referred any Partner, Children or Additional Family
-          //  - an <18 has not referred any Parent, Brother or Sister or Additional Family
-          condition: req => {
-            if (Utilities.isOver18(req.sessionModel.get('date-of-birth'))) {
-              return (req.sessionModel.get('partner') === 'no' &&
-                req.sessionModel.get('children') === 'no' &&
-                req.sessionModel.get('additional-family') === 'no');
-            }
-            return (req.sessionModel.get('parent') === 'no' &&
-              req.sessionModel.get('brother-or-sister') === 'no' &&
-              req.sessionModel.get('additional-family') === 'no');
-          }
+          condition: req => noFamilyReferred(req),
         }
       ],
       locals: { showSaveAndExit: true },
@@ -718,6 +724,12 @@ module.exports = {
         SaveFormSession,
         ModifySummaryChangeLinks,
         EditRouteStart
+      ],
+      forks: [
+        {
+          target: '/no-family-referred',
+          condition: req => noFamilyReferred(req),
+        }
       ],
       sections: require('./sections/summary-data-sections'),
       locals: { showSaveAndExit: true },

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -66,6 +66,7 @@ module.exports = {
       forks: [
         {
           target: '/full-name',
+          continueOnEdit: false,
           condition: {
             field: 'who-completing-form',
             value: 'the-referrer'
@@ -74,6 +75,7 @@ module.exports = {
         },
         {
           target: '/helper-details',
+          continueOnEdit: true,
           condition: {
             field: 'who-completing-form',
             value: 'someone-helping'
@@ -81,6 +83,7 @@ module.exports = {
         },
         {
           target: '/immigration-adviser-details',
+          continueOnEdit: true,
           condition: {
             field: 'who-completing-form',
             value: 'immigration-advisor'
@@ -88,9 +91,7 @@ module.exports = {
         }
       ],
       fields: ['who-completing-form'],
-      locals: { showSaveAndExit: true },
-      continueOnEdit: true,
-      next: '/helper-details'
+      locals: { showSaveAndExit: true }
     },
     '/helper-details': {
       behaviours: SaveFormSession,
@@ -112,7 +113,6 @@ module.exports = {
         'is-legal-representative-email',
         'legal-representative-email'
       ],
-      continueOnEdit: true,
       locals: { showSaveAndExit: true },
       next: '/complete-as-referrer'
     },

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -602,7 +602,7 @@ module.exports = {
 
     '/family-in-uk': {
       behaviours: [
-        ResetSummary('family-member-in-uk', 'family-in-uk'),
+        ResetSummary('uk-family-aggregate', 'family-in-uk'),
         SaveFormSession
       ],
       forks: [
@@ -640,7 +640,7 @@ module.exports = {
     },
     '/family-in-uk-summary': {
       behaviours: [AggregateSaveUpdate, limitFamilyInUk, familyInUkSummary, SaveFormSession],
-      aggregateTo: 'family-member-in-uk',
+      aggregateTo: 'uk-family-aggregate',
       aggregateFrom: [
         'family-member-fullname',
         'family-member-relationship',

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -54,8 +54,8 @@ const yesPlusAggregation = (req, formValue, sessionModel) => {
   ) {
     return true;
   }
-  return false;  
-}
+  return false;
+};
 
 /**
  * Is the form value 'yes' and the aggregation empty?
@@ -73,8 +73,8 @@ const yesEmptyAggregation = (req, formValue, sessionModel) => {
   ) {
     return true;
   }
-  return false;  
-}
+  return false;
+};
 
 
 module.exports = {
@@ -371,12 +371,12 @@ module.exports = {
     '/partner': {
       behaviours: [
         ResetSummary('referred-partners', 'partner'),
-        SaveFormSession, 
+        SaveFormSession,
         EditRouteReturn
       ],
       fields: ['partner'],
       forks: [
-        // partner -> yes -> partner summary (skipping details if already exist)        
+        // partner -> yes -> partner summary (skipping details if already exist)
         {
           target: '/partner-summary',
           condition: req => yesPlusAggregation(req, 'partner', 'referred-partners'),
@@ -386,10 +386,10 @@ module.exports = {
           target: '/partner-details',
           condition: req => yesEmptyAggregation(req, 'partner', 'referred-partners'),
           continueOnEdit: true
-        }, 
+        }
       ],
       locals: { showSaveAndExit: true },
-      next: '/children',
+      next: '/children'
     },
     '/partner-details': {
       fields: [
@@ -440,7 +440,7 @@ module.exports = {
 
     '/children': {
       behaviours: [
-        ResetSummary('referred-children', 'children'), 
+        ResetSummary('referred-children', 'children'),
         SaveFormSession,
         EditRouteReturn
       ],
@@ -507,8 +507,8 @@ module.exports = {
 
     '/additional-family': {
       behaviours: [
-        ResetSummary('referred-additional-family', 'additional-family'), 
-        SaveFormSession, 
+        ResetSummary('referred-additional-family', 'additional-family'),
+        SaveFormSession,
         Locals18Flag,
         EditRouteReturn
       ],
@@ -557,7 +557,7 @@ module.exports = {
         'additional-family-why-referring'
       ],
       behaviours: [
-        LimitAdditionalFamily, 
+        LimitAdditionalFamily,
         SaveFormSession,
         EditRouteReturn
       ],
@@ -567,9 +567,9 @@ module.exports = {
     },
     '/additional-family-summary': {
       behaviours: [
-        AggregateSaveUpdate, 
-        AdditionalFamilySummary, 
-        LimitAdditionalFamily, 
+        AggregateSaveUpdate,
+        AdditionalFamilySummary,
+        LimitAdditionalFamily,
         SaveFormSession,
         EditRouteReturn
       ],
@@ -601,7 +601,10 @@ module.exports = {
     },
 
     '/family-in-uk': {
-      behaviours: [ResetSummary('family-member-in-uk', 'family-in-uk'), SaveFormSession],
+      behaviours: [
+        ResetSummary('family-member-in-uk', 'family-in-uk'),
+        SaveFormSession
+      ],
       forks: [
         {
           target: '/family-in-uk-details',
@@ -653,6 +656,7 @@ module.exports = {
       continueOnEdit: true,
       next: '/upload-evidence'
     },
+
     '/upload-evidence': {
       behaviours: [SaveFormSession, SaveImage('image'), RemoveImage, LimitDocument],
       fields: ['image'],

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -28,6 +28,7 @@ const DeclarationBehaviour = require('./behaviours/declaration');
 const PartnerSummary = require('./behaviours/partner-summary');
 const LimitPartners = require('./behaviours/limit-partners');
 const ExitToSignIn = require('./behaviours/exit-to-sign-in');
+const EditRouteStart = require('./behaviours/edit-route-start');
 
 // Aggregator section limits
 const PARENT_LIMIT = 2;
@@ -56,7 +57,13 @@ module.exports = {
       backLink: false
     },
     '/information-you-have-given-us': {
-      behaviours: [ExitToSignIn, SummaryPageBehaviour, CheckInformationGivenBehaviour, ModifySummaryChangeLinks],
+      behaviours: [
+        ExitToSignIn,
+        SummaryPageBehaviour,
+        CheckInformationGivenBehaviour,
+        ModifySummaryChangeLinks,
+        EditRouteStart
+      ],
       sections: require('./sections/summary-data-sections'),
       backLink: false,
       journeyStart: '/who-completing-form'
@@ -66,7 +73,6 @@ module.exports = {
       forks: [
         {
           target: '/full-name',
-          continueOnEdit: false,
           condition: {
             field: 'who-completing-form',
             value: 'the-referrer'
@@ -653,7 +659,12 @@ module.exports = {
       next: '/confirm'
     },
     '/confirm': {
-      behaviours: [SummaryPageBehaviour, SaveFormSession, ModifySummaryChangeLinks],
+      behaviours: [
+        SummaryPageBehaviour,
+        SaveFormSession,
+        ModifySummaryChangeLinks,
+        EditRouteStart
+      ],
       sections: require('./sections/summary-data-sections'),
       locals: { showSaveAndExit: true },
       next: '/declaration'

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -80,10 +80,10 @@ const yesEmptyAggregation = (req, formValue, aggregateName) => {
  * 'no-family-referred' occurs when:
  * - an >18 has not referred any Partner, Children or Additional Family
  * - an <18 has not referred any Parent, Brother or Sister or Additional Family
- * 
+ *
  * @return {boolean} True if no family members are referred
  */
-const noFamilyReferred = (req) => {
+const noFamilyReferred = req => {
   if (Utilities.isOver18(req.sessionModel.get('date-of-birth'))) {
     return (req.sessionModel.get('partner') === 'no' &&
       req.sessionModel.get('children') === 'no' &&
@@ -92,7 +92,7 @@ const noFamilyReferred = (req) => {
   return (req.sessionModel.get('parent') === 'no' &&
     req.sessionModel.get('brother-or-sister') === 'no' &&
     req.sessionModel.get('additional-family') === 'no');
-}
+};
 
 
 module.exports = {
@@ -544,7 +544,7 @@ module.exports = {
         },
         {
           target: '/no-family-referred',
-          condition: req => noFamilyReferred(req),
+          condition: req => noFamilyReferred(req)
         }
       ],
       locals: { showSaveAndExit: true },
@@ -728,7 +728,7 @@ module.exports = {
       forks: [
         {
           target: '/no-family-referred',
-          condition: req => noFamilyReferred(req),
+          condition: req => noFamilyReferred(req)
         }
       ],
       sections: require('./sections/summary-data-sections'),

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -29,6 +29,7 @@ const PartnerSummary = require('./behaviours/partner-summary');
 const LimitPartners = require('./behaviours/limit-partners');
 const ExitToSignIn = require('./behaviours/exit-to-sign-in');
 const EditRouteStart = require('./behaviours/edit-route-start');
+const EditRouteReturn = require('./behaviours/edit-route-return');
 
 // Aggregator section limits
 const PARENT_LIMIT = 2;
@@ -69,7 +70,7 @@ module.exports = {
       journeyStart: '/who-completing-form'
     },
     '/who-completing-form': {
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       forks: [
         {
           target: '/full-name',
@@ -77,7 +78,7 @@ module.exports = {
             field: 'who-completing-form',
             value: 'the-referrer'
           },
-          continueOnEdit: true
+          continueOnEdit: false
         },
         {
           target: '/helper-details',
@@ -100,13 +101,13 @@ module.exports = {
       locals: { showSaveAndExit: true }
     },
     '/helper-details': {
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       fields: ['helper-full-name', 'helper-relationship', 'helper-organisation'],
       locals: { showSaveAndExit: true },
       next: '/complete-as-referrer'
     },
     '/immigration-adviser-details': {
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       fields: [
         'legal-representative-fullname',
         'legal-representative-organisation',
@@ -123,7 +124,7 @@ module.exports = {
       next: '/complete-as-referrer'
     },
     '/complete-as-referrer': {
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       next: '/full-name',
       locals: { showSaveAndExit: true }
     },
@@ -146,10 +147,11 @@ module.exports = {
         condition: {
           field: 'confirm-your-email',
           value: 'no'
-        }
+        },
+        continueOnEdit: true
       }],
       next: '/provide-telephone-number',
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       locals: { showSaveAndExit: true }
     },
 
@@ -158,7 +160,7 @@ module.exports = {
         'your-email-options',
         'your-email-address'
       ],
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       locals: { showSaveAndExit: true },
       next: '/provide-telephone-number'
     },
@@ -167,12 +169,12 @@ module.exports = {
         'provide-telephone-number-options',
         'provide-telephone-number-number'
       ],
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       locals: { showSaveAndExit: true },
       next: '/your-address'
     },
     '/your-address': {
-      behaviours: SaveFormSession,
+      behaviours: [SaveFormSession, EditRouteReturn],
       fields: [
         'your-address-line-1',
         'your-address-line-2',
@@ -186,7 +188,11 @@ module.exports = {
     // Figma Section: "Who are you applying to bring to the UK? Sponsor under 18" (who-bringing-parent)
 
     '/parent': {
-      behaviours: [ResetSummary('referred-parents', 'parent'), SaveFormSession],
+      behaviours: [
+        ResetSummary('referred-parents', 'parent'), 
+        SaveFormSession, 
+        EditRouteReturn
+      ],
       fields: ['parent'],
       forks: [
         {
@@ -194,7 +200,8 @@ module.exports = {
           condition: {
             field: 'parent',
             value: 'yes'
-          }
+          },
+          continueOnEdit: true
         },
         {
           target: '/brother-or-sister',

--- a/apps/acrs/index.js
+++ b/apps/acrs/index.js
@@ -43,14 +43,14 @@ const PARTNER_LIMIT = 1;
  *
  * @param {Object} req - The request god object.
  * @param {string} formValue - The name of the req.form.values field to check is 'yes.
- * @param {string} sessionModel - The name of the req.sessionModel to check has a populated array
+ * @param {string} aggregateName - The name of the req.sessionModel to check has a populated array (== aggregateTo)
  * @return {boolean} Returns true if the form value is 'yes' and  has aggregated values, otherwise false.
  */
-const yesPlusAggregation = (req, formValue, sessionModel) => {
+const yesPlusAggregation = (req, formValue, aggregateName) => {
   if (
     req.form.values[formValue] === 'yes' &&
-    req.sessionModel.get(sessionModel) &&
-    req.sessionModel.get(sessionModel).aggregatedValues.length > 0
+    req.sessionModel.get(aggregateName) &&
+    req.sessionModel.get(aggregateName).aggregatedValues.length > 0
   ) {
     return true;
   }
@@ -62,14 +62,14 @@ const yesPlusAggregation = (req, formValue, sessionModel) => {
  *
  * @param {Object} req - The request god object.
  * @param {string} formValue - The name of the form value to check.
- * @param {string} sessionModel - The name of the session model to check.
+ * @param {string} aggregateName - The name of the session model to check. (== aggregateTo)
  * @return {boolean} Returns true if the form value is 'yes' and the aggregation is empty, otherwise false.
  */
-const yesEmptyAggregation = (req, formValue, sessionModel) => {
+const yesEmptyAggregation = (req, formValue, aggregateName) => {
   if (
     req.form.values[formValue] === 'yes' &&
-    ( !req.sessionModel.get(sessionModel) ||
-      req.sessionModel.get(sessionModel).aggregatedValues.length === 0)
+    ( !req.sessionModel.get(aggregateName) ||
+      req.sessionModel.get(aggregateName).aggregatedValues.length === 0)
   ) {
     return true;
   }
@@ -610,12 +610,12 @@ module.exports = {
       forks: [
         {
           target: '/family-in-uk-summary',
-          condition: req => yesPlusAggregation(req, 'has-family-in-uk', 'family-member-in-uk'),
+          condition: req => yesPlusAggregation(req, 'has-family-in-uk', 'uk-family-aggregate'),
           continueOnEdit: true
         },
         {
           target: '/family-in-uk-details',
-          condition: req => yesEmptyAggregation(req, 'has-family-in-uk', 'family-member-in-uk'),
+          condition: req => yesEmptyAggregation(req, 'has-family-in-uk', 'uk-family-aggregate'),
           continueOnEdit: true
         }
       ],

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -18,8 +18,10 @@ const addressFormatter = (model, fieldNames) => {
 const aggregateParser = (aggregate, titleField, dobField = 'date-of-birth') => {
   for (const item of aggregate) {
     item.fields.map(field => {
+      // All the fields in the aggregated values have their Change link removed.
       field.omitChangeLink = true;
       if (field.field === titleField) {
+        // One field is promoted to Title so that it receives the "Change" link
         field.isAggregatorTitle = true;
       }
       if (field.field.includes(dobField) && field.value !== undefined) {

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -338,7 +338,7 @@ module.exports = {
       },
       {
         step: '/family-in-uk-summary',
-        field: 'family-member-in-uk',
+        field: 'uk-family-aggregate',
         addElementSeparators: true,
         dependsOn: 'has-family-in-uk',
         parse: obj => {

--- a/apps/acrs/views/partials/summary-table.html
+++ b/apps/acrs/views/partials/summary-table.html
@@ -3,37 +3,45 @@
 </div>
 <dl>
   {{#fields}}
-  {{^omitFromSummary}}
-  {{#isAggregatorTitle}}
-    <div class="table-options">
-     <h2 class="govuk-table__caption--M">{{value}}</h2>
-      {{#changeLink}}
-        <dd><span><a class="govuk-link" href="{{changeLink}}" id="{{field}}-change-{{index}}">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
-      {{/changeLink}}
-      {{^changeLink}}
-        <dd><span><a class="govuk-link" href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
-      {{/changeLink}}
-    </div>
-  {{/isAggregatorTitle}}
-    <div class="confirm-row">
-      {{#isSeparator}}
-      {{/isSeparator}}
-      {{^isSeparator}}
+    {{^omitFromSummary}}
+      {{#isAggregatorTitle}}
+        <div class="table-options">
+         <h2 class="govuk-table__caption--M">{{value}}</h2>
+          {{#changeLink}}
+            <dd><span>
+              <a class="govuk-link" href="{{changeLink}}" id="{{field}}-change-{{index}}">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a>
+            </span></dd>
+          {{/changeLink}}
+          {{^changeLink}}
+            <dd><span>
+              <a class="govuk-link" href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a>
+            </span></dd>
+          {{/changeLink}}
+        </div>
+      {{/isAggregatorTitle}}
+      <div class="confirm-row">
+        {{#isSeparator}}
+        {{/isSeparator}}
+        {{^isSeparator}}
         <dt class="confirm-label">{{label}}</dt>
-        <dd class="confirm-value" data-value="{{value}}">{{value}}</dd>
-      {{^omitChangeLink}}
-        {{#changeLink}}
-          <dd><span><a class="govuk-link" href="{{changeLink}}" id="{{field}}-change-{{index}}">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
-        {{/changeLink}}
-        {{^changeLink}}
-          <dd><span><a class="govuk-link" href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a></span></dd>
-        {{/changeLink}}
-      {{/omitChangeLink}}
-      {{#omitChangeLink}}
-        <dd> </dd>
-      {{/omitChangeLink}}
-      {{/isSeparator}}
-    </div>
-  {{/omitFromSummary}}
+          <dd class="confirm-value" data-value="{{value}}">{{value}}</dd>
+        {{^omitChangeLink}}
+          {{#changeLink}}
+            <dd><span>
+              <a class="govuk-link" href="{{changeLink}}" id="{{field}}-change-{{index}}">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a>
+            </span></dd>
+          {{/changeLink}}
+          {{^changeLink}}
+            <dd><span>
+              <a class="govuk-link" href="{{baseUrl}}{{step}}/edit#{{field}}" id="{{field}}-change">{{#t}}buttons.change{{/t}} <span class="visuallyhidden">{{changeLinkDescription}} from {{value}}</span></a>
+            </span></dd>
+          {{/changeLink}}
+        {{/omitChangeLink}}
+        {{#omitChangeLink}}
+          <dd> </dd>
+        {{/omitChangeLink}}
+        {{/isSeparator}}
+      </div>
+    {{/omitFromSummary}}
   {{/fields}}
 </dl>

--- a/test/_unit/edit-route-return.spec.js
+++ b/test/_unit/edit-route-return.spec.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 const EditRouteReturn = require('../../apps/acrs/behaviours/edit-route-return');
 
 class SuperClass {}
@@ -54,20 +55,20 @@ describe('isContinueOnEdit', () => {
   });
 
   it('should return true if a matching choice with continueOnEdit is found whose condition is function', () => {
-    const req = {
+    const request = {
       form: {
         values: { 'hof-field-B': 'other-stuff', 'hof-field-A': 'some-input'},
         options: {
           forks: [
             {
-              condition: (req) => true,
+              condition: req => true,
               continueOnEdit: true
             }
           ]
         }
       }
     };
-    const result = objEditRouteReturn.isContinueOnEdit(req);
+    const result = objEditRouteReturn.isContinueOnEdit(request);
 
     expect(result).to.be.true;
   });
@@ -119,14 +120,14 @@ describe('isContinueOnEdit', () => {
 
 describe('isForkSelected', () => {
   it('should return the true when condition is a function that is fulfilled', () => {
-    const condition = (req) => {
-      return req.form.values.parent === 'yes' && 
+    const condition = req => {
+      return req.form.values.parent === 'yes' &&
         req.session.aggregatedValues.length === 0;
     };
     const req = {
       form: {
         values: {
-          'parent': 'yes'
+          parent: 'yes'
         }
       },
       session: {
@@ -138,14 +139,14 @@ describe('isForkSelected', () => {
   });
 
   it('should return false when condition is a function that is not fulfilled', () => {
-    const condition = (req) => {
-      return req.form.values.parent === 'yes' && 
+    const condition = req => {
+      return req.form.values.parent === 'yes' &&
         req.session.aggregatedValues.length === 0;
     };
     const req = {
       form: {
         values: {
-          'parent': 'yes'
+          parent: 'yes'
         }
       },
       session: {
@@ -186,5 +187,5 @@ describe('isForkSelected', () => {
     };
     const result = objEditRouteReturn.isForkSelected(condition, req);
     expect(result).to.be.false;
-  });  
+  });
 });

--- a/test/_unit/edit-route-return.spec.js
+++ b/test/_unit/edit-route-return.spec.js
@@ -1,18 +1,18 @@
-const SaveFormSession = require('../../apps/acrs/behaviours/save-form-session');
+const EditRouteReturn = require('../../apps/acrs/behaviours/edit-route-return');
 
 class SuperClass {}
-const isChoiceContinueOnEdit = (new (SaveFormSession(SuperClass))).isChoiceContinueOnEdit;
+const isContinueOnEdit = (new (EditRouteReturn(SuperClass))).isContinueOnEdit;
 
-describe('isChoiceContinueOnEdit', () => {
+describe('isContinueOnEdit', () => {
   it('should return false if options.continueOnEdit is falsy', () => {
     const values = { 'hof-field-A': 'some-input' };
 
     let options = {};
-    let result = isChoiceContinueOnEdit(options, values);
+    let result = isContinueOnEdit(options, values);
     expect(result).to.be.false;
 
     options = { continueOnEdit: false };
-    result = isChoiceContinueOnEdit(options, values);
+    result = isContinueOnEdit(options, values);
     expect(result).to.be.false;
   });
 
@@ -20,7 +20,7 @@ describe('isChoiceContinueOnEdit', () => {
     const values = { 'hof-field-A': 'some-input' };
 
     options = { continueOnEdit: true };
-    result = isChoiceContinueOnEdit(options, values);
+    result = isContinueOnEdit(options, values);
     expect(result).to.be.true;
   });
 
@@ -37,7 +37,7 @@ describe('isChoiceContinueOnEdit', () => {
       ]
     };
     const values = { 'hof-field-B': 'other-stuff', 'hof-field-A': 'some-input'};
-    const result = isChoiceContinueOnEdit(options, values);
+    const result = isContinueOnEdit(options, values);
 
     expect(result).to.be.true;
   });
@@ -55,7 +55,7 @@ describe('isChoiceContinueOnEdit', () => {
       ]
     };
     const values = { 'hof-field-A': 'different-input' };
-    const result = isChoiceContinueOnEdit(options, values);
+    const result = isContinueOnEdit(options, values);
 
     expect(result).to.be.false;
   });
@@ -72,7 +72,7 @@ describe('isChoiceContinueOnEdit', () => {
       ]
     };
     const values = { 'hof-field-A': 'some-input'};
-    const result = isChoiceContinueOnEdit(options, values);
+    const result = isContinueOnEdit(options, values);
 
     expect(result).to.be.false;
   });

--- a/test/_unit/edit-route-return.spec.js
+++ b/test/_unit/edit-route-return.spec.js
@@ -1,79 +1,190 @@
 const EditRouteReturn = require('../../apps/acrs/behaviours/edit-route-return');
 
 class SuperClass {}
-const isContinueOnEdit = (new (EditRouteReturn(SuperClass))).isContinueOnEdit;
+const objEditRouteReturn = (new (EditRouteReturn(SuperClass)));
 
 describe('isContinueOnEdit', () => {
   it('should return false if options.continueOnEdit is falsy', () => {
-    const values = { 'hof-field-A': 'some-input' };
-
-    let options = {};
-    let result = isContinueOnEdit(options, values);
+    const req = {
+      form: {
+        values: {
+          'hof-field-A': 'some-input'
+        },
+        options: {}
+      }
+    };
+    let result = objEditRouteReturn.isContinueOnEdit(req);
     expect(result).to.be.false;
 
-    options = { continueOnEdit: false };
-    result = isContinueOnEdit(options, values);
+    req.form.options.continueOnEdit = false;
+    result = objEditRouteReturn.isContinueOnEdit(req);
     expect(result).to.be.false;
   });
 
   it('should return true if options.continueOnEdit is truthy', () => {
-    const values = { 'hof-field-A': 'some-input' };
-
-    options = { continueOnEdit: true };
-    result = isContinueOnEdit(options, values);
+    const req = {
+      form: {
+        values: { 'hof-field-A': 'some-input' },
+        options: { continueOnEdit: true }
+      }
+    };
+    const result = objEditRouteReturn.isContinueOnEdit(req);
     expect(result).to.be.true;
   });
 
   it('should return true if a matching choice with continueOnEdit is found', () => {
-    const options = {
-      forks: [
-        {
-          condition: {
-            field: 'hof-field-A',
-            value: 'some-input'
-          },
-          continueOnEdit: true
+    const req = {
+      form: {
+        values: { 'hof-field-B': 'other-stuff', 'hof-field-A': 'some-input'},
+        options: {
+          forks: [
+            {
+              condition: {
+                field: 'hof-field-A',
+                value: 'some-input'
+              },
+              continueOnEdit: true
+            }
+          ]
         }
-      ]
+      }
     };
-    const values = { 'hof-field-B': 'other-stuff', 'hof-field-A': 'some-input'};
-    const result = isContinueOnEdit(options, values);
+    const result = objEditRouteReturn.isContinueOnEdit(req);
+    expect(result).to.be.true;
+  });
+
+  it('should return true if a matching choice with continueOnEdit is found whose condition is function', () => {
+    const req = {
+      form: {
+        values: { 'hof-field-B': 'other-stuff', 'hof-field-A': 'some-input'},
+        options: {
+          forks: [
+            {
+              condition: (req) => true,
+              continueOnEdit: true
+            }
+          ]
+        }
+      }
+    };
+    const result = objEditRouteReturn.isContinueOnEdit(req);
 
     expect(result).to.be.true;
   });
 
   it('should return false if no matching choice is found', () => {
-    const options = {
-      forks: [
-        {
-          condition: {
-            field: 'hof-field-A',
-            value: 'some-input'
-          },
-          continueOnEdit: true
+    const req = {
+      form: {
+        values: { 'hof-field-A': 'different-input' },
+        options: {
+          forks: [
+            {
+              condition: {
+                field: 'hof-field-A',
+                value: 'some-input'
+              },
+              continueOnEdit: true
+            }
+          ]
         }
-      ]
+      }
     };
-    const values = { 'hof-field-A': 'different-input' };
-    const result = isContinueOnEdit(options, values);
+    const result = objEditRouteReturn.isContinueOnEdit(req);
 
     expect(result).to.be.false;
   });
 
   it('should return false if a matching choice is found but continueOnEdit is falsy', () => {
-    const options = {
-      forks: [
-        {
-          condition: {
-            field: 'hof-field-A',
-            value: 'some-input'
-          }
+    const req = {
+      form: {
+        values: { 'hof-field-A': 'some-input' },
+        options: {
+          forks: [
+            {
+              condition: {
+                field: 'hof-field-A',
+                value: 'some-input'
+              },
+              continueOnEdit: false
+            }
+          ]
         }
-      ]
+      }
     };
-    const values = { 'hof-field-A': 'some-input'};
-    const result = isContinueOnEdit(options, values);
+    const result = objEditRouteReturn.isContinueOnEdit(req);
 
     expect(result).to.be.false;
   });
+});
+
+describe('isForkSelected', () => {
+  it('should return the true when condition is a function that is fulfilled', () => {
+    const condition = (req) => {
+      return req.form.values.parent === 'yes' && 
+        req.session.aggregatedValues.length === 0;
+    };
+    const req = {
+      form: {
+        values: {
+          'parent': 'yes'
+        }
+      },
+      session: {
+        aggregatedValues: []
+      }
+    };
+    const result = objEditRouteReturn.isForkSelected(condition, req);
+    expect(result).to.be.true;
+  });
+
+  it('should return false when condition is a function that is not fulfilled', () => {
+    const condition = (req) => {
+      return req.form.values.parent === 'yes' && 
+        req.session.aggregatedValues.length === 0;
+    };
+    const req = {
+      form: {
+        values: {
+          'parent': 'yes'
+        }
+      },
+      session: {
+        aggregatedValues: ['not-empty']
+      }
+    };
+    const result = objEditRouteReturn.isForkSelected(condition, req);
+    expect(result).to.be.false;
+  });
+
+  it('should return true when condition is an object field/value that is matched by values', () => {
+    const condition = {
+      field: 'hof-field-A',
+      value: 'some-input'
+    };
+    const req = {
+      form: {
+        values: {
+          'hof-field-A': 'some-input'
+        }
+      }
+    };
+    const result = objEditRouteReturn.isForkSelected(condition, req);
+    expect(result).to.be.true;
+  });
+
+  it('should return false when condition is an object field/value that is not matched by values', () => {
+    const condition = {
+      field: 'hof-field-A',
+      value: 'different-input'
+    };
+    const req = {
+      form: {
+        values: {
+          'hof-field-A': 'some-input'
+        }
+      }
+    };
+    const result = objEditRouteReturn.isForkSelected(condition, req);
+    expect(result).to.be.false;
+  });  
 });

--- a/test/_unit/save-form-session.spec.js
+++ b/test/_unit/save-form-session.spec.js
@@ -1,0 +1,79 @@
+const SaveFormSession = require('../../apps/acrs/behaviours/save-form-session');
+
+class SuperClass {}
+const isChoiceContinueOnEdit = (new (SaveFormSession(SuperClass))).isChoiceContinueOnEdit;
+
+describe('isChoiceContinueOnEdit', () => {
+  it('should return false if options.continueOnEdit is falsy', () => {
+    const values = { 'hof-field-A': 'some-input' };
+
+    let options = {};
+    let result = isChoiceContinueOnEdit(options, values);
+    expect(result).to.be.false;
+
+    options = { continueOnEdit: false };
+    result = isChoiceContinueOnEdit(options, values);
+    expect(result).to.be.false;
+  });
+
+  it('should return true if options.continueOnEdit is truthy', () => {
+    const values = { 'hof-field-A': 'some-input' };
+
+    options = { continueOnEdit: true };
+    result = isChoiceContinueOnEdit(options, values);
+    expect(result).to.be.true;
+  });
+
+  it('should return true if a matching choice with continueOnEdit is found', () => {
+    const options = {
+      forks: [
+        {
+          condition: {
+            field: 'hof-field-A',
+            value: 'some-input'
+          },
+          continueOnEdit: true
+        }
+      ]
+    };
+    const values = { 'hof-field-B': 'other-stuff', 'hof-field-A': 'some-input'};
+    const result = isChoiceContinueOnEdit(options, values);
+
+    expect(result).to.be.true;
+  });
+
+  it('should return false if no matching choice is found', () => {
+    const options = {
+      forks: [
+        {
+          condition: {
+            field: 'hof-field-A',
+            value: 'some-input'
+          },
+          continueOnEdit: true
+        }
+      ]
+    };
+    const values = { 'hof-field-A': 'different-input' };
+    const result = isChoiceContinueOnEdit(options, values);
+
+    expect(result).to.be.false;
+  });
+
+  it('should return false if a matching choice is found but continueOnEdit is falsy', () => {
+    const options = {
+      forks: [
+        {
+          condition: {
+            field: 'hof-field-A',
+            value: 'some-input'
+          }
+        }
+      ]
+    };
+    const values = { 'hof-field-A': 'some-input'};
+    const result = isChoiceContinueOnEdit(options, values);
+
+    expect(result).to.be.false;
+  });
+});


### PR DESCRIPTION
## What? 

[ACRS-185 Summary Change Routing](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-185)

This ticket address the problem of routing the looping sections from the Summary pages. When a user re-entered a looping section, for instance `/children` some of the routes would not return to the summary but would continue through the standard happy path.

This problem is addressed by providing two new behaviours that set-up and return-from a Change route by storing the return url in the session and checking for it when a loop section is complete. Additionally the urls for the Change links to the looping section "Question" (intro) page have been modified to prevent them from jumping straight into the sections -details pages.

An additional check for `no-family-referred` has been added to the `/confirm` page to prevent empty referrals being submitted.