### PR TITLE
ACRS-211-Bugfix For over 1500 characters

### DIFF
--- a/config.js
+++ b/config.js
@@ -88,5 +88,7 @@ module.exports = {
   uniqueReferralRefs: {
     refLength: 6,
     refAllowedChars: 'ABCDEFGHJKMNPRTUVWXY0123456789'
-  }
+  },
+  urlEncodedLimitSize: process.env.URL_ENCODED_LIMIT_SIZE || '2mb',
+  jsonLimitSize: process.env.JSON_LIMIT_SIZE || '2mb'
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bytes": "^3.1.2",
     "crypto-random-string": "^5.0.0",
     "dotenv": "^16.3.1",
-    "hof": "~20.5.0",
+    "hof": "20.5.7-Beta-payload-too-large",
     "ioredis": "^5.4.1",
     "jquery": "^3.7.1",
     "lodash": "^4.17.21",

--- a/server.js
+++ b/server.js
@@ -15,6 +15,7 @@ settings = Object.assign({}, settings, {
   behaviours: settings.behaviours.map(require)
 });
 
+
 if (!fs.existsSync(config.dataDirectory)) {
   fs.mkdirSync(config.dataDirectory);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3121,10 +3121,10 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hof@~20.5.0:
-  version "20.5.2"
-  resolved "https://registry.yarnpkg.com/hof/-/hof-20.5.2.tgz#1a7a5660fd8a92991903619b18fca5c7e624201c"
-  integrity sha512-TdENaThMn36S6J2vpjRoujAEtJuDKmkwUEfuqVyXZFOqboFN1/nuC9NnYimKkcxvMxq61rWQDsmwNgO/wQN6cQ==
+hof@20.5.7-Beta-payload-too-large:
+  version "20.5.7-Beta-payload-too-large"
+  resolved "https://registry.yarnpkg.com/hof/-/hof-20.5.7-Beta-payload-too-large.tgz#b04fb9ee3449eafad622a51668aa1eae174cdc58"
+  integrity sha512-9kFekPljshg5UpY0TUu80hsikWCM2ffl57NhNNZMpPaNSXapHnhl+TK3Lr7lDqJPWWLE14cewl5ICkP+thV8Lg==
   dependencies:
     aliasify "^2.1.0"
     bluebird "^3.7.2"


### PR DESCRIPTION
## What? 
[ACRS-211](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-211). - known Error sometimes when over 15000 characters entered

## Why? 
When user enters more than 1500 characters in any textbox that requires max length of 1500, validation error message is not triggered instead a payload too large error appears once click on save and continue button.

[Change of HOF Version 20.5.2](https://github.com/UKHomeOfficeForms/hof/compare/v20.5.2...master)

[Changes of HOF Version 20.6.0](https://github.com/UKHomeOfficeForms/hof/compare/v20.5.6...master)

## How? 
-  I have added this changes to HOF framework version :
 21.0.1 and 20.5.7-Beta-payload-too-large.

-  Added two variable in the config.js to allow a dynamic body parser size be increased by developer.

## Testing?
Tested manually on local machine 

## Screenshots (optional)

<img width="1143" alt="Screenshot 2024-07-22 at 16 35 44" src="https://github.com/user-attachments/assets/e48e7342-44d5-4d56-ae74-393c82415e05">
<img width="1186" alt="Screenshot 2024-07-22 at 16 35 58" src="https://github.com/user-attachments/assets/27a5dc24-ddc9-44b3-9bf4-849da700eba0">


## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
