### PR TITLE
ACRS-218 Bugfix DOB Month defaulting

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -26,12 +26,12 @@ ignore:
   SNYK-JS-REQUEST-3361831:
     - '*':
         reason: HOF framework needs updating to remove request.js
-        expires: 2024-08-01T00:00:00.000Z
+        expires: 2024-10-01T00:00:00.000Z
         created: 2023-08-09T13:22:47.350Z
   SNYK-JS-TOUGHCOOKIE-5672873:
     - '*':
         reason: HOF framework needs updating to remove request.js of which this is a dependency
-        expires: 2024-08-01T00:00:00.000Z
+        expires: 2024-10-01T00:00:00.000Z
         created: 2023-08-09T13:22:47.350Z
   SNYK-JS-USERAGENT-174737:
     - device > useragent:

--- a/apps/acrs/behaviours/additional-family-summary.js
+++ b/apps/acrs/behaviours/additional-family-summary.js
@@ -25,7 +25,7 @@ module.exports = superclass => class extends superclass {
         // Process a value to parse and reformat it before render
         if (field.field.includes('date-of-birth')) {
           if (field.value !== undefined) {
-            field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+            field.parsed = moment(field.value).format('DD MMMM YYYY');
           }
         }
         // Appending a value to the field name here allows us to render text from fields.json instead of the fieldname

--- a/apps/acrs/behaviours/brother-sister-summary.js
+++ b/apps/acrs/behaviours/brother-sister-summary.js
@@ -25,7 +25,7 @@ module.exports = superclass => class extends superclass {
         // Process a value to parse and reformat it before render
         if (field.field.includes('date-of-birth')) {
           if (field.value !== undefined) {
-            field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+            field.parsed = moment(field.value).format('DD MMMM YYYY');
           }
         }
         // Appending a value to the field name here allows us to render text from fields.json instead of the fieldname

--- a/apps/acrs/behaviours/children-summary.js
+++ b/apps/acrs/behaviours/children-summary.js
@@ -28,7 +28,7 @@ module.exports = superclass => class extends superclass {
       item.fields = item.fields.map(field => {
         if (field.field.includes('date-of-birth')) {
           if (field.value !== undefined) {
-            field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+            field.parsed = moment(field.value).format('DD MMMM YYYY');
           }
         }
         field.field += '.summary-heading';

--- a/apps/acrs/behaviours/family-in-uk-summary.js
+++ b/apps/acrs/behaviours/family-in-uk-summary.js
@@ -26,7 +26,7 @@ module.exports = superclass => class extends superclass {
         // Process a value to parse and reformat it before render
         if (field.field.includes('date-of-birth')) {
           if (field.value !== undefined) {
-            field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+            field.parsed = moment(field.value).format('DD MMMM YYYY');
           }
         }
         // Appending a value to the field name here allows us to render text from fields.json instead of the fieldname

--- a/apps/acrs/behaviours/parent-summary.js
+++ b/apps/acrs/behaviours/parent-summary.js
@@ -24,7 +24,7 @@ module.exports = superclass => class extends superclass {
         // Process a value to parse and reformat it before render
         if (field.field.includes('date-of-birth')) {
           if (field.value !== undefined) {
-            field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+            field.parsed = moment(field.value).format('DD MMMM YYYY');
           }
         }
         // Appending a value to the field name here allows us to render text from fields.json instead of the fieldname

--- a/apps/acrs/behaviours/partner-summary.js
+++ b/apps/acrs/behaviours/partner-summary.js
@@ -27,7 +27,7 @@ module.exports = superclass => class extends superclass {
       item.fields = item.fields.map(field => {
         if (field.field.includes('date-of-birth')) {
           if (field.value !== undefined) {
-            field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+            field.parsed = moment(field.value).format('DD MMMM YYYY');
           }
         }
         field.field += '.summary-heading';

--- a/apps/acrs/sections/summary-data-sections.js
+++ b/apps/acrs/sections/summary-data-sections.js
@@ -25,7 +25,7 @@ const aggregateParser = (aggregate, titleField, dobField = 'date-of-birth') => {
         field.isAggregatorTitle = true;
       }
       if (field.field.includes(dobField) && field.value !== undefined) {
-        field.parsed = moment(field.value, 'YYYY-MMMM-DD').format(PRETTY_DATE_FORMAT);
+        field.parsed = moment(field.value).format(PRETTY_DATE_FORMAT);
       }
       return field;
     });
@@ -254,7 +254,7 @@ module.exports = {
               field.omitChangeLink = true;
               if (field.field.includes('date-of-birth')) {
                 if (field.value !== undefined) {
-                  field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+                  field.parsed = moment(field.value).format('DD MMMM YYYY');
                 }
               }
               return field;
@@ -278,7 +278,7 @@ module.exports = {
               field.omitChangeLink = true;
               if (field.field.includes('date-of-birth')) {
                 if (field.value !== undefined) {
-                  field.parsed = moment(field.value, 'YYYY-MMMM-DD').format('DD MMMM YYYY');
+                  field.parsed = moment(field.value).format('DD MMMM YYYY');
                 }
               }
               return field;


### PR DESCRIPTION
## What? 
[ACRS-218](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-218) - DOB Month Defaulting to January

## Why? 
The month of birth when entering family members in the form is defaulting to January. This needs to be checked on all family screens (parent, partner, brother/sister, children, additional family, family in UK) to ensure that the correct month of birth is saved

## How? 
In each summary page there was an issue with the moment library for date format which prevent the original daate from formatting then setting it to default.
- I have removed the date format from each summary page behaviour to enable render the exact date
- Added 2 security vulnerabilities to .synk list

## Testing?
Tested locally

## Screenshots (optional)
<img width="1192" alt="Screenshot 2024-08-01 at 11 01 23" src="https://github.com/user-attachments/assets/96c409cf-a6f3-4304-92d3-afa6ec0db723">
<img width="949" alt="Screenshot 2024-08-01 at 11 22 54" src="https://github.com/user-attachments/assets/cf489493-e6a5-476d-8bc1-ff9cff8715da">
<img width="939" alt="Screenshot 2024-08-01 at 11 23 17" src="https://github.com/user-attachments/assets/e8c6f17e-603c-404e-808d-bedf971cc6ed">
<img width="1070" alt="Screenshot 2024-08-01 at 11 23 35" src="https://github.com/user-attachments/assets/4a22156f-eca0-4cad-b7c1-3194a6b571be">
<img width="989" alt="Screenshot 2024-08-01 at 11 29 30" src="https://github.com/user-attachments/assets/0d35da14-cee9-4b92-8c55-efe30bfc8176">
<img width="915" alt="Screenshot 2024-08-01 at 11 29 55" src="https://github.com/user-attachments/assets/b9a6e8b7-cfe7-4fff-9861-e569634ef0b3">
<img width="870" alt="Screenshot 2024-08-01 at 11 30 05" src="https://github.com/user-attachments/assets/ed15e394-4a4c-40d0-9dc7-128094fd2ba7">
<img width="959" alt="Screenshot 2024-08-01 at 11 30 22" src="https://github.com/user-attachments/assets/12968a0e-9078-4acd-bec8-efe2e5f0e52a">


## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
