### PR TITLE
ACRS-219-Bugfix Link not working

### DIFF
--- a/apps/verify/views/content/accessibility.md
+++ b/apps/verify/views/content/accessibility.md
@@ -1,7 +1,7 @@
 # Accessibility statement for Refer family to come to the UK (Afghan Citizens Resettlement Scheme)
 
 
-This accessibility statement applies to the [www.refer-afghan-family-to-come-to-the-uk.homeoffice.gov.uk](www.refer-afghan-family-to-come-to-the-uk.homeoffice.gov.uk) website. It does not cover related pages on the [www.gov.uk](www.gov.uk) website, which has its own accessibility statement.
+This accessibility statement applies to the [www.refer-afghan-family-to-come-to-the-uk.homeoffice.gov.uk](https://www.refer-afghan-family-to-come-to-the-uk.homeoffice.gov.uk) website. It does not cover related pages on the [www.gov.uk](https://www.gov.uk) website, which has its own accessibility statement.
 
 This website is run by the Home Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
 


### PR DESCRIPTION
## What? 
[ACRS-219](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-219)   Accessibility Statement - Link to Form Leading to Page not found

## Why? 
The first two link in the Accessibility Statement page not redirecting properly

## How? 
- Added http:// to the link on markdown page

## Testing?
Tested locally 
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
