### PR TITLE
ACRS-216 Bugfix doesn't get updated

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -17,7 +17,7 @@ ignore:
   SNYK-JS-AXIOS-6032459:
     - '*':
         reason: Cross-site Request Forgery (CSRF) needs to be upgraded in HOF to latest version
-        expires: '2024-09-15T00:00:00.000Z'
+        expires: '2024-11-15T00:00:00.000Z'
   SNYK-JS-SEMVER-3247795:
     - '*':
         reason: notifications-node-client needs to be upgraded in HOF to latest version
@@ -115,6 +115,26 @@ ignore:
     - '*':
       reason: Issues with no direct upgrade or patch.
       expires: '2024-07-03T00:00:00.000Z'
+  SNYK-JS-BODYPARSER-7926860:
+    - '*':
+      reason: Issues with no direct upgrade or patch.
+      expires: '2024-11-03T00:00:00.000Z'
+  SNYK-JS-EXPRESS-7926867:
+    - '*':
+      reason: Issues with no direct upgrade or patch.
+      expires: '2024-11-03T00:00:00.000Z'
+  SNYK-JS-PATHTOREGEXP-7925106:
+    - '*':
+      reason: Issues with no direct upgrade or patch.
+      expires: '2024-11-03T00:00:00.000Z'
+  SNYK-JS-SEND-7926862:
+    - '*':
+      reason: Issues with no direct upgrade or patch.
+      expires: '2024-11-03T00:00:00.000Z'
+  SNYK-JS-SERVESTATIC-7926865:
+    - '*':
+      reason: Issues with no direct upgrade or patch.
+      expires: '2024-11-03T00:00:00.000Z'
   SNYK-JS-BRACES-6838727:
     - '*':
       reason: No upgrade or patch available

--- a/apps/acrs/behaviours/edit-route-return.js
+++ b/apps/acrs/behaviours/edit-route-return.js
@@ -8,6 +8,22 @@ module.exports = superclass => class extends superclass {
 
       const shouldContinueOnEdit = this.isContinueOnEdit(req);
       const editReturnPath = req.sessionModel.get('edit-return-path');
+
+      if(req.sessionModel.get('who-completing-form') === 'the-referrer') {
+        req.sessionModel.unset('helper-full-name');
+        req.sessionModel.unset('helper-relationship');
+        req.sessionModel.unset('helper-organisation');
+        req.sessionModel.unset('legal-representative-fullname');
+        req.sessionModel.unset('legal-representative-organisation');
+        req.sessionModel.unset('legal-representative-house-number');
+        req.sessionModel.unset('legal-representative-street');
+        req.sessionModel.unset('legal-representative-townOrCity');
+        req.sessionModel.unset('legal-representative-county');
+        req.sessionModel.unset('legal-representative-postcode');
+        req.sessionModel.unset('legal-representative-phone-number');
+        req.sessionModel.unset('is-legal-representative-email');
+        req.sessionModel.unset('legal-representative-email');
+      }
       if ( !shouldContinueOnEdit && editReturnPath) {
         return res.redirect(editReturnPath);
       }

--- a/apps/acrs/behaviours/edit-route-start.js
+++ b/apps/acrs/behaviours/edit-route-start.js
@@ -10,6 +10,24 @@ module.exports = superclass => class extends superclass {
 
   saveValues(req, res, next) {
     req.sessionModel.unset('edit-return-path');
+
+
+    if(req.sessionModel.get('who-completing-form') === 'the-referrer') {
+      req.sessionModel.unset('helper-full-name');
+      req.sessionModel.unset('helper-relationship');
+      req.sessionModel.unset('helper-organisation');
+      req.sessionModel.unset('legal-representative-fullname');
+      req.sessionModel.unset('legal-representative-organisation');
+      req.sessionModel.unset('legal-representative-house-number');
+      req.sessionModel.unset('legal-representative-street');
+      req.sessionModel.unset('legal-representative-townOrCity');
+      req.sessionModel.unset('legal-representative-county');
+      req.sessionModel.unset('legal-representative-postcode');
+      req.sessionModel.unset('legal-representative-phone-number');
+      req.sessionModel.unset('is-legal-representative-email');
+      req.sessionModel.unset('legal-representative-email');
+    }
+
     return super.saveValues(req, res, next);
   }
 };


### PR DESCRIPTION
## What? 
[ACRS-216](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-216) - Check your answers page change link doesn't get updated for who is completing this form

## Why? 
-Upon selecting a new option, the displayed details should update to reflect the information associated with the new selection.
- Despite the change, the displayed details continue to show the information from the initial selection.

## How? 
- Unset the value when different option is selected in the edit-route-return and edit-route-start.js file behaviour
- Add list of vulnerabilities to .synk file

## Testing?
Tested on local machine
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
