### PR TITLE
HOFF-1179: Update hof-rds-api image to latest v3.1.0

### DIFF
--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -32,8 +32,8 @@ spec:
     spec:
       containers:
         - name: data-service
-          # release v2.0.1
-          image: quay.io/ukhomeofficedigital/hof-rds-api:16bc712744851373e533d94ecf04724836be8247
+          # hof-rds-api: v3.0.0 updated on 16/04/2025
+          image: quay.io/ukhomeofficedigital/hof-rds-api:3.0.0@sha256:31aaea007a4415cc9cb24270011c98d1a814e3c097f22a82203759c6483997b4
           imagePullPolicy: Always
           envFrom:
             - configMapRef:

--- a/kube/hof-rds-api/deployment.yml
+++ b/kube/hof-rds-api/deployment.yml
@@ -32,8 +32,8 @@ spec:
     spec:
       containers:
         - name: data-service
-          # hof-rds-api: v3.0.0 updated on 16/04/2025
-          image: quay.io/ukhomeofficedigital/hof-rds-api:3.0.0@sha256:31aaea007a4415cc9cb24270011c98d1a814e3c097f22a82203759c6483997b4
+          # hof-rds-api: v3.1.0 updated on 10/06/2025
+          image: quay.io/ukhomeofficedigital/hof-rds-api:3.1.0@sha256:e73edb96b62bc5dbce4e56b49ac41e7b7bf2e601fb7b0b71dbd19251c8a8e317
           imagePullPolicy: Always
           envFrom:
             - configMapRef:


### PR DESCRIPTION
## What?
* Using hof-rds-api image with hof-nodejs image and upgraded node packages
* Tested and replaced in all the remaining HOF services
* Fixed vulnerabilities in the image
* Testing in Branch env
* https://collaboration.homeoffice.gov.uk/jira/browse/HOFF-1179

## Why?

* Large number of Critical and High CVE Vulnerabilities have been detected by Trivy Scan
* This image has fixed the vulnerabilties
* Drone build with Trivy scan report, https://drone-gh.acp.homeoffice.gov.uk/UKHomeOffice/hof-rds-api/223

## How?

* Replace hof-rds-api image with latest
* Add a comment to explain the version and Date.


## Testing?
* Regression testing in Branch and then merge to master to deploy and test in UAT, Stage and promote to Prod
* Check boxes will ticked as we pass through each env
- [ ] Branch
- [ ] UAT
- [ ] Stage
- [ ] Prod

## Screenshots (optional)

## Anything Else? (optional)
* Drone build is successful
* Pods are Healthy
* Staging environment has been commented out in pipeline 4 years ago by team

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging