### PR TITLE
ACRS-274: The button displayed on additional family member page label…

### DIFF
--- a/apps/acrs/views/additional-family.html
+++ b/apps/acrs/views/additional-family.html
@@ -17,6 +17,6 @@
     </p>
     <p class="govuk-body">{{#t}}pages.additional-family.paragraph-3{{/t}}</p>
     {{#renderField}}additional-family{{/renderField}}
-    {{#input-submit}}continue-only{{/input-submit}}
+    {{#input-submit}}continue{{/input-submit}}
   {{/page-content}}
 {{/partials-page}}


### PR DESCRIPTION
…ed as Save and Continue.

## What? 
Incorrect button displayed on Additional family members page should labeled Save and Continue
## Why? 
[ACRS-274](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-274)
## How? 
Changed continue-only to continue, which will display as Save and continue.
## Testing?
Manual testing conducted.
## Screenshots (optional)
![image](https://github.com/user-attachments/assets/fa088906-43fb-42eb-a9f2-9e9c4dec947f)

## Anything Else? (optional)
There were 2 pages request in this ticket. But the second page doesn't need to change the label. Please see ticket comments.
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
