### PR TITLE
ACRS-278-update-nginx-image: Use latest nginx image with fixed vulnerabilities…

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -191,8 +191,8 @@ spec:
               name: public
 
         - name: nginx-proxy
-          # nginx-proxy-govuk:v4
-          image: quay.io/ukhomeofficedigital/nginx-proxy-govuk@sha256:4470064d0b1d20ae08c5fd85551576cb687f342a22d6cb456fda9b2c4ce8c8df
+          # nginx-proxy:v0.0.6
+          image: quay.io/ukhomeofficedigital/hof-docker-nginx-proxy:0.0.6
           resources:
             requests:
               memory: 20Mi

--- a/kube/file-vault/file-vault-deployment.yml
+++ b/kube/file-vault/file-vault-deployment.yml
@@ -187,8 +187,8 @@ spec:
               readOnly: true
 
         - name: nginx-proxy
-          # nginx-proxy-govuk:v4
-          image: quay.io/ukhomeofficedigital/nginx-proxy-govuk@sha256:4470064d0b1d20ae08c5fd85551576cb687f342a22d6cb456fda9b2c4ce8c8df
+          # nginx-proxy:v0.0.6
+          image: quay.io/ukhomeofficedigital/hof-docker-nginx-proxy:0.0.6
           resources:
             limits:
               memory: 1024Mi


### PR DESCRIPTION
## What? 
* Following changes have been made to the Nginx image:
* Upgraded Nginx Image from version 0.0.4 to 0.0.6 and tagged the image accordingly.
* Switched the base image from Centos to Alma Linux 9.5 to ensure compatibility with Trivy vulnerability scanning.

## Why? 
To upgrade image used by nginx

## How? 
Adding newly built image

## Testing?
Manual

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
