### PR TITLE
adding depends on to allow the prod deploy step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -400,6 +400,8 @@ steps:
     when:
       target: PROD
       event: promote
+    depends_on:
+      - clone_repos_prod
 
   # CRON job step that tears down our pull request UAT environments
   - name: cron_tear_down


### PR DESCRIPTION
## What? 
The final step has a depends up
This pull request introduces a dependency update in the Drone CI pipeline configuration, specifically for the production deployment workflow. The change ensures that the `promote` step for the `PROD` target waits for the `clone_repos_prod` step to complete before executing.
## Why? 
To fix release issue
## How? 
Pipeline dependency update:

* [`.drone.yml`](diffhunk://#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7R403-R404): Added `depends_on: - clone_repos_prod` to the `promote` step for the `PROD` target, enforcing correct step execution order in the CI/CD pipeline.
*
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
