### PR TITLE
ACRS-286: Removed ampersand from the sending verification email link.…

### DIFF
--- a/apps/verify/behaviours/send-verification-email.js
+++ b/apps/verify/behaviours/send-verification-email.js
@@ -14,9 +14,9 @@ const _ = require('lodash');
 const getPersonalisation = (host, token, idType) => {
   const protocol = host.includes('localhost') ? 'http' : 'https';
   return {
-    // pass in `&` at the end in case there is another
-    // query e.g. ?hof-cookie-check
-    link: `${protocol}://${host + config.login.appPath}?token=${token}&`,
+    // removed `&` from the url
+    // hof-cookie-check appending to the base url from hof framework correctly
+    link: `${protocol}://${host + config.login.appPath}?token=${token}`,
     host: `${protocol}://${host}`,
     idType: idType === 'brp' ? 'BRP number' : 'UAN'
   };

--- a/apps/verify/behaviours/send-verification-email.js
+++ b/apps/verify/behaviours/send-verification-email.js
@@ -14,8 +14,6 @@ const _ = require('lodash');
 const getPersonalisation = (host, token, idType) => {
   const protocol = host.includes('localhost') ? 'http' : 'https';
   return {
-    // removed `&` from the url
-    // hof-cookie-check appending to the base url from hof framework correctly
     link: `${protocol}://${host + config.login.appPath}?token=${token}`,
     host: `${protocol}://${host}`,
     idType: idType === 'brp' ? 'BRP number' : 'UAN'


### PR DESCRIPTION
… As per the existing comment, hof-cookie-check param added correctly to the url from hof framework, so no need additional ampersand here. Also couldn't find any other issue after testing without ampersand.

## What? 
[https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-286](https://collaboration.homeoffice.gov.uk/jira/browse/ACRS-286)
## Why? 
Due to invalid verification url, page denied the request to proceed.
## How? 
Removed ampersand from the email verification url.
## Testing?
## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
